### PR TITLE
Add ability to load blocks/blocks.json

### DIFF
--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -178,7 +178,7 @@ class Loader extends Component_Abstract {
 	}
 
 	/**
-	 * Load all the published blocks.
+	 * Load all the published blocks and blocks/block.json files.
 	 */
 	public function retrieve_blocks() {
 
@@ -186,6 +186,20 @@ class Loader extends Component_Abstract {
 
 		$this->blocks = '';
 		$blocks       = [];
+
+		// Retrieve blocks from blocks.json.
+		// Reverse to preserve order of preference when using array_merge.
+		$blocks_files = array_reverse( (array) abc_locate_template( 'blocks/blocks.json', '', false ) );
+		foreach ( $blocks_files as $blocks_file ) {
+			// This is expected to be on the local filesystem, so file_get_contents() is ok to use here.
+			$json = file_get_contents( $blocks_file );
+			$block_data = json_decode( $json, true );
+
+			// Merge if no json_decode error occurred.
+			if ( json_last_error() == JSON_ERROR_NONE ) {
+				$blocks = array_merge( $blocks, $block_data );
+			}
+		}
 
 		$block_posts = new \WP_Query( [
 			'post_type'      => $slug,

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -145,5 +145,12 @@ function abc_locate_template( $template_names, $path = '', $single = true ) {
 		}
 	}
 
-	return $single ? array_shift( $located ) : array_values( array_unique( $located ) );
+	// Remove duplicates and re-index array.
+	$located = array_values( array_unique( $located ) );
+
+	if ( $single ) {
+		return array_shift( $located );
+	}
+
+	return $located;
 }

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -28,7 +28,7 @@ function acb_field( $key, $echo = true ) {
 /**
  * Convenience method to return the value of an ACB block field.
  *
- * @param string $key  The name of the field as created in the UI.
+ * @param string $key The name of the field as created in the UI.
  *
  * @uses acb_field()
  *
@@ -48,7 +48,7 @@ function acb_template_part( $slug, $type = 'block' ) {
 
 	// Loading async it might not come from a query, this breaks load_template();
 	global $wp_query;
-	
+
 	// So lets fix it.
 	if ( empty( $wp_query ) ) {
 		$wp_query = new WP_Query();
@@ -58,15 +58,15 @@ function acb_template_part( $slug, $type = 'block' ) {
 	$located       = '';
 	$template_file = '';
 
-	foreach( $types as $type ) {
+	foreach ( $types as $type ) {
 
 		if ( ! empty( $located ) ) {
 			continue;
 		}
 
 		$template_file = "blocks/{$type}-{$slug}.php";
-		$generic_file = "blocks/{$type}.php";
-		$templates = [
+		$generic_file  = "blocks/{$type}.php";
+		$templates     = [
 			$generic_file,
 			$template_file,
 		];
@@ -74,7 +74,7 @@ function acb_template_part( $slug, $type = 'block' ) {
 		$located = abc_locate_template( $templates );
 	}
 
-	if ( ! empty( $located) ) {
+	if ( ! empty( $located ) ) {
 		$theme_template = apply_filters( 'acb_override_theme_template', $located );
 
 		// This is not a load once template, so require_once is false.
@@ -96,37 +96,54 @@ function acb_template_part( $slug, $type = 'block' ) {
  * and allows to be called when STYLESHEET_PATH has not been set yet. Handy for async.
  *
  * @param string|array $template_names Templates to locate.
- * @param string       $path (Optional) Path to located the templates first.
+ * @param string       $path           (Optional) Path to located the templates first.
+ * @param bool         $single         `true` - Returns only the first found item. Like standard `locate_template`
+ *                                     `false` - Returns all found templates.
  *
- * @return string
+ * @return string|array
  */
-function abc_locate_template( $template_names, $path = '' ) {
+function abc_locate_template( $template_names, $path = '', $single = true ) {
 
-	$path  = apply_filters( 'acb_template_path', $path );
+	$path            = apply_filters( 'acb_template_path', $path );
 	$stylesheet_path = get_template_directory();
 	$template_path   = get_stylesheet_directory();
 
-	$located = '';
+	$located = [];
 
 	foreach ( (array) $template_names as $template_name ) {
 
-		if ( !$template_name ) {
+		if ( ! $template_name ) {
 			continue;
 		}
 
 		if ( ! empty( $path ) && file_exists( $path . '/' . $template_name ) ) {
-			$located = $path . '/' . $template_name;
-		} elseif ( file_exists($stylesheet_path . '/' . $template_name)) {
-			$located = $stylesheet_path . '/' . $template_name;
-			break;
-		} elseif ( file_exists($template_path . '/' . $template_name) ) {
-			$located = $template_path . '/' . $template_name;
-			break;
-		} elseif ( file_exists( ABSPATH . WPINC . '/theme-compat/' . $template_name ) ) {
-			$located = ABSPATH . WPINC . '/theme-compat/' . $template_name;
-			break;
+			$located[] = $path . '/' . $template_name;
+			if ( $single ) {
+				break;
+			}
+		}
+
+		if ( file_exists( $stylesheet_path . '/' . $template_name ) ) {
+			$located[] = $stylesheet_path . '/' . $template_name;
+			if ( $single ) {
+				break;
+			}
+		}
+
+		if ( file_exists( $template_path . '/' . $template_name ) ) {
+			$located[] = $template_path . '/' . $template_name;
+			if ( $single ) {
+				break;
+			}
+		}
+
+		if ( file_exists( ABSPATH . WPINC . '/theme-compat/' . $template_name ) ) {
+			$located[] = ABSPATH . WPINC . '/theme-compat/' . $template_name;
+			if ( $single ) {
+				break;
+			}
 		}
 	}
 
-	return $located;
+	return $single ? array_shift( $located ) : array_values( array_unique( $located ) );
 }


### PR DESCRIPTION
Users can create blocks by specifying a `blocks/blocks.json` file with the block definitions.  The file follows the same order of preference as template files... 1. filtered path first, 2. then current theme, 3. then parent theme if current theme is a child theme.

Although this was a roadmap item, I felt it was important to add this feature now.

I will allow me to define blocks in `blocks.json` which is not yet supported by the UI.  This will help me to continue the work required on the Gutenberg-JSX side of development.