### PR TITLE
Bugfix: Draft blocks

### DIFF
--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -133,6 +133,10 @@ class Loader extends Component_Abstract {
 	public function get_block_attributes( $block ) {
 		$attributes = [];
 
+		if ( ! isset( $block['fields'] ) ) {
+			return $attributes;
+		}
+
 		foreach ( $block['fields'] as $field_name => $field ) {
 			$attributes[ $field_name ] = [];
 


### PR DESCRIPTION
This fixes an undefined index error that happened when you start creating a new block, and it saves a draft, and then you close the window.