### PR TITLE
Ensure that Gutenberg respects field types

### DIFF
--- a/php/blocks/class-block.php
+++ b/php/blocks/class-block.php
@@ -123,7 +123,7 @@ class Block {
 
 		if ( isset( $config['fields'] ) ) {
 			foreach ( $config['fields'] as $field ) {
-				$field_defaults = array( 'name', 'label', 'control', 'location', 'order' );
+				$field_defaults = array( 'name', 'label', 'control', 'type', 'location', 'order' );
 				$field_settings = array_diff( array_keys( $field ), $field_defaults );
 				foreach ( $field_settings as $setting ) {
 					$field['settings'][ $setting ] = $field[ $setting ];
@@ -151,6 +151,7 @@ class Block {
 			$config['fields'][ $key ]['name']     = $field->name;
 			$config['fields'][ $key ]['label']    = $field->label;
 			$config['fields'][ $key ]['control']  = $field->control;
+			$config['fields'][ $key ]['type']     = $field->type;
 			$config['fields'][ $key ]['location'] = $field->location;
 			$config['fields'][ $key ]['order']    = $field->order;
 

--- a/php/blocks/class-field.php
+++ b/php/blocks/class-field.php
@@ -36,6 +36,13 @@ class Field {
 	public $control = 'text';
 
 	/**
+	 * Field variable type.
+	 *
+	 * @var string
+	 */
+	public $type = 'string';
+
+	/**
 	 * Field location.
 	 *
 	 * @var string
@@ -70,6 +77,9 @@ class Field {
 		}
 		if ( isset( $args['control'] ) ) {
 			$this->control = $args['control'];
+		}
+		if ( isset( $args['type'] ) ) {
+			$this->type = $args['type'];
 		}
 		if ( isset( $args['location'] ) ) {
 			$this->location = $args['location'];

--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -106,10 +106,9 @@ class Loader extends Component_Abstract {
 
 		// Get blocks.
 		$blocks = json_decode( $this->blocks, true );
+
 		foreach ( $blocks as $block_name => $block ) {
 			$attributes = $this->get_block_attributes( $block );
-
-			$attributes['block_name'] = $block_name;
 
 			// sanitize_title() allows underscores, but register_block_type doesn't.
 			$block_name = str_replace( '_', '-', $block_name );
@@ -154,16 +153,16 @@ class Loader extends Component_Abstract {
 				$attributes[ $field_name ]['type'] = 'string';
 			}
 
+			if ( ! empty( $field['default'] ) ) {
+				$attributes[ $field_name ]['default'] = $field['default'];
+			}
+
 			if ( ! empty( $field['source'] ) ) {
 				$attributes[ $field_name ]['source'] = $field['source'];
 			}
 
 			if ( ! empty( $field['meta'] ) ) {
 				$attributes[ $field_name ]['meta'] = $field['meta'];
-			}
-
-			if ( ! empty( $field['default'] ) ) {
-				$attributes[ $field_name ]['default'] = $field['default'];
 			}
 
 			if ( ! empty( $field['selector'] ) ) {

--- a/php/blocks/controls/class-checkbox.php
+++ b/php/blocks/controls/class-checkbox.php
@@ -22,6 +22,13 @@ class Checkbox extends Control_Abstract {
 	public $name = 'checkbox';
 
 	/**
+	 * Field variable type.
+	 *
+	 * @var string
+	 */
+	public $type = 'boolean';
+
+	/**
 	 * Checkbox constructor.
 	 *
 	 * @return void

--- a/php/blocks/controls/class-control-abstract.php
+++ b/php/blocks/controls/class-control-abstract.php
@@ -31,6 +31,13 @@ abstract class Control_Abstract {
 	public $label = '';
 
 	/**
+	 * Field variable type.
+	 *
+	 * @var string
+	 */
+	public $type = 'string';
+
+	/**
 	 * Control settings.
 	 *
 	 * @var Control_Setting[]

--- a/php/blocks/controls/class-range.php
+++ b/php/blocks/controls/class-range.php
@@ -22,6 +22,13 @@ class Range extends Control_Abstract {
 	public $name = 'range';
 
 	/**
+	 * Field variable type.
+	 *
+	 * @var string
+	 */
+	public $type = 'integer';
+
+	/**
 	 * Range constructor.
 	 *
 	 * @return void

--- a/php/blocks/controls/class-select.php
+++ b/php/blocks/controls/class-select.php
@@ -22,6 +22,13 @@ class Select extends Control_Abstract {
 	public $name = 'select';
 
 	/**
+	 * Field variable type.
+	 *
+	 * @var string
+	 */
+	public $type = 'text';
+
+	/**
 	 * Select constructor.
 	 *
 	 * @return void

--- a/php/blocks/controls/class-toggle.php
+++ b/php/blocks/controls/class-toggle.php
@@ -22,6 +22,13 @@ class Toggle extends Control_Abstract {
 	public $name = 'toggle';
 
 	/**
+	 * Field variable type.
+	 *
+	 * @var string
+	 */
+	public $type = 'boolean';
+
+	/**
 	 * Toggle constructor.
 	 *
 	 * @return void

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -29,6 +29,18 @@ function block_field( $key, $echo = true ) {
 	$value = $block_lab_attributes[ $key ];
 
 	if ( $echo ) {
+		if ( is_array( $value ) ) {
+			$value = implode( ', ', $value );
+		}
+
+		if ( true === $value ) {
+			$value = __( 'Yes', 'block-lab' );
+		}
+
+		if ( false === $value ) {
+			$value = __( 'No', 'block-lab' );
+		}
+
 		/**
 		 * Escaping this value may cause it to break in some use cases.
 		 * If this happens, retrieve the field's value using block_value(),

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -806,8 +806,13 @@ class Block_Post extends Component_Abstract {
 					);
 				}
 
+				// Field type.
+				if ( isset( $field_config['control'] ) && isset( $this->controls[ $field_config['control'] ] ) ) {
+					$field_config['type'] = $this->controls[ $field_config['control'] ]->type;
+				}
+
 				// Field settings.
-				if ( isset( $this->controls[ $field_config['control'] ] ) ) {
+				if ( isset( $field_config['control'] ) && isset( $this->controls[ $field_config['control'] ] ) ) {
 					$control = $this->controls[ $field_config['control'] ];
 					foreach ( $control->settings as $setting ) {
 						if ( isset( $_POST['block-fields-settings'][ $key ][ $setting->name ] ) ) {


### PR DESCRIPTION
This one took quite a lot of work! Got there in the end, but please test carefully.

This fixes broken checkboxes, toggle controls, and range controls (which previously only returned their default value).

Resolves #104.