### PR TITLE
mixin exposing the full block parameters like labels, types …

### DIFF
--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -187,8 +187,9 @@ class Loader extends Component_Abstract {
 	 * @return mixed
 	 */
 	public function render_block_template( $block, $attributes, $type = 'block' ) {
-		global $block_lab_attributes;
+		global $block_lab_attributes, $block_lab_block;
 		$block_lab_attributes = $attributes;
+		$block_lab_block = $block;
 
 		ob_start();
 		block_lab_template_part( $block['name'], $type );

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -66,6 +66,16 @@ function block_value( $key ) {
 }
 
 /**
+ * Convenience method to return the block object.
+ *
+ * @return mixed|null
+ */
+function block_params( ) {
+	global $block_lab_block;
+	return $block_lab_block;
+}
+
+/**
  * Loads a template part to render the block.
  *
  * @param string $slug The name of the block (slug as defined in UI).


### PR DESCRIPTION
Hi there.

I've discover recently Guntenberg, an your plugin. It's helpful ! 
Thank's

So I've to simply retrieve the label, an the only available mixin concerns _value_ of fields. 
And so, I've expose a new mixin `block_params()` returning all params of current block, available in the template. 

Usage example in my theme block template:
```php
<?php
	$block = block_params();

	foreach ($block['fields'] as $field_name => $field) {

		?>
		<h2><?= $field['label'] ?></h2>
		<p><?php block_field( $field_name ) ?></p>
		<?php

	}
```

Thank you. 
Arthur. 