### PR TITLE
Feature/148 violy

### DIFF
--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -187,8 +187,9 @@ class Loader extends Component_Abstract {
 	 * @return mixed
 	 */
 	public function render_block_template( $block, $attributes, $type = 'block' ) {
-		global $block_lab_attributes;
+		global $block_lab_attributes, $block_lab_block;
 		$block_lab_attributes = $attributes;
+		$block_lab_block = $block;
 
 		ob_start();
 		block_lab_template_part( $block['name'], $type );

--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -187,9 +187,9 @@ class Loader extends Component_Abstract {
 	 * @return mixed
 	 */
 	public function render_block_template( $block, $attributes, $type = 'block' ) {
-		global $block_lab_attributes, $block_lab_block;
+		global $block_lab_attributes, $block_lab_config;
 		$block_lab_attributes = $attributes;
-		$block_lab_block = $block;
+		$block_lab_config     = $block;
 
 		ob_start();
 		block_lab_template_part( $block['name'], $type );

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -66,13 +66,28 @@ function block_value( $key ) {
 }
 
 /**
- * Convenience method to return the block object.
+ * Convenience method to return the block configuration.
  *
- * @return mixed|null
+ * @return array
  */
-function block_params( ) {
-	global $block_lab_block;
-	return $block_lab_block;
+function block_config() {
+	global $block_lab_config;
+	return $block_lab_config;
+}
+
+/**
+ * Convenience method to return a field's configuration.
+ *
+ * @param string $key The name of the field as created in the UI.
+ *
+ * @return array|null
+ */
+function block_field_config( $key ) {
+	global $block_lab_config;
+	if ( ! isset( $block_lab_config['fields'][ $key ] ) ) {
+		return null;
+	}
+	return $block_lab_config['fields'][ $key ];
 }
 
 /**

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -66,6 +66,16 @@ function block_value( $key ) {
 }
 
 /**
+ * Convenience method to return the block object.
+ *
+ * @return mixed|null
+ */
+function block_params( ) {
+	global $block_lab_block;
+	return $block_lab_block;
+}
+
+/**
  * Loads a template part to render the block.
  *
  * @param string $slug The name of the block (slug as defined in UI).


### PR DESCRIPTION
Based on @violy's work in #148. Added methods for viewing block config, or a fields config.

Note – after merging this PR, docs must be added for the `block_config` and `block_field_config` functions.