### PR TITLE
Fix problems with quotes and slashes in the post title or field data

### DIFF
--- a/php/blocks/class-block.php
+++ b/php/blocks/class-block.php
@@ -148,8 +148,6 @@ class Block {
 			}
 		}
 
-		$config = stripslashes_deep( $config );
-
 		return wp_json_encode( array( 'block-lab/' . $this->name => $config ), JSON_UNESCAPED_UNICODE );
 	}
 }

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -795,7 +795,9 @@ class Block_Post extends Component_Abstract {
 		}
 
 		// Block title.
-		$block->title = sanitize_text_field( $data['post_title'] );
+		$block->title = sanitize_text_field(
+			wp_unslash( $data['post_title'] )
+		);
 		if ( '' === $block->title ) {
 			$block->title = $post_id;
 		}
@@ -884,7 +886,7 @@ class Block_Post extends Component_Abstract {
 			}
 		}
 
-		$data['post_content'] = $block->to_json();
+		$data['post_content'] = wp_slash( $block->to_json() );
 		return $data;
 	}
 


### PR DESCRIPTION
This should resolve all of these issues once and for all!

Here's some of the strings I used to test:
> "keywords",'keywords',\keywords\

> Testing: A "complex' title* 💅🏿 with special&nbsp; \&כעיח ©haracters

> a ' b " c \ d \' e \" f \\ g

Resolves #154 