### PR TITLE
Update the field help setting

### DIFF
--- a/php/blocks/controls/class-checkbox.php
+++ b/php/blocks/controls/class-checkbox.php
@@ -46,10 +46,10 @@ class Checkbox extends Control_Abstract {
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( array(
 			'name'     => 'help',
-			'label'    => __( 'Field instructions', 'block-lab' ),
-			'type'     => 'textarea',
+			'label'    => __( 'Help Text', 'block-lab' ),
+			'type'     => 'text',
 			'default'  => '',
-			'sanitize' => 'sanitize_textarea_field',
+			'sanitize' => 'sanitize_text_field',
 		) );
 		$this->settings[] = new Control_Setting( array(
 			'name'     => 'default',

--- a/php/blocks/controls/class-email.php
+++ b/php/blocks/controls/class-email.php
@@ -40,10 +40,10 @@ class Email extends Control_Abstract {
 		$this->settings[] = new Control_Setting(
 			array(
 				'name'     => 'help',
-				'label'    => __( 'Field instructions', 'block-lab' ),
-				'type'     => 'textarea',
+				'label'    => __( 'Help Text', 'block-lab' ),
+				'type'     => 'text',
 				'default'  => '',
-				'sanitize' => 'sanitize_textarea_field',
+				'sanitize' => 'sanitize_text_field',
 			)
 		);
 		$this->settings[] = new Control_Setting(

--- a/php/blocks/controls/class-multiselect.php
+++ b/php/blocks/controls/class-multiselect.php
@@ -46,10 +46,10 @@ class Multiselect extends Control_Abstract {
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( array(
 			'name'     => 'help',
-			'label'    => __( 'Field instructions', 'block-lab' ),
-			'type'     => 'textarea',
+			'label'    => __( 'Help Text', 'block-lab' ),
+			'type'     => 'text',
 			'default'  => '',
-			'sanitize' => 'sanitize_textarea_field',
+			'sanitize' => 'sanitize_text_field',
 		) );
 		$this->settings[] = new Control_Setting( array(
 			'name'     => 'options',

--- a/php/blocks/controls/class-number.php
+++ b/php/blocks/controls/class-number.php
@@ -47,10 +47,10 @@ class Number extends Control_Abstract {
 		$this->settings[] = new Control_Setting(
 			array(
 				'name'     => 'help',
-				'label'    => __( 'Field instructions', 'block-lab' ),
-				'type'     => 'textarea',
+				'label'    => __( 'Help Text', 'block-lab' ),
+				'type'     => 'text',
 				'default'  => '',
-				'sanitize' => 'sanitize_textarea_field',
+				'sanitize' => 'sanitize_text_field',
 			)
 		);
 		$this->settings[] = new Control_Setting(

--- a/php/blocks/controls/class-radio.php
+++ b/php/blocks/controls/class-radio.php
@@ -39,10 +39,10 @@ class Radio extends Control_Abstract {
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( array(
 			'name'     => 'help',
-			'label'    => __( 'Field instructions', 'block-lab' ),
-			'type'     => 'textarea',
+			'label'    => __( 'Help Text', 'block-lab' ),
+			'type'     => 'text',
 			'default'  => '',
-			'sanitize' => 'sanitize_textarea_field',
+			'sanitize' => 'sanitize_text_field',
 		) );
 		$this->settings[] = new Control_Setting( array(
 			'name'     => 'options',

--- a/php/blocks/controls/class-range.php
+++ b/php/blocks/controls/class-range.php
@@ -46,10 +46,10 @@ class Range extends Control_Abstract {
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( array(
 			'name'     => 'help',
-			'label'    => __( 'Field instructions', 'block-lab' ),
-			'type'     => 'textarea',
+			'label'    => __( 'Help Text', 'block-lab' ),
+			'type'     => 'text',
 			'default'  => '',
-			'sanitize' => 'sanitize_textarea_field',
+			'sanitize' => 'sanitize_text_field',
 		) );
 		$this->settings[] = new Control_Setting( array(
 			'name'     => 'min',

--- a/php/blocks/controls/class-select.php
+++ b/php/blocks/controls/class-select.php
@@ -39,10 +39,10 @@ class Select extends Control_Abstract {
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( array(
 			'name'     => 'help',
-			'label'    => __( 'Field instructions', 'block-lab' ),
-			'type'     => 'textarea',
+			'label'    => __( 'Help Text', 'block-lab' ),
+			'type'     => 'text',
 			'default'  => '',
-			'sanitize' => 'sanitize_textarea_field',
+			'sanitize' => 'sanitize_text_field',
 		) );
 		$this->settings[] = new Control_Setting( array(
 			'name'     => 'options',

--- a/php/blocks/controls/class-text.php
+++ b/php/blocks/controls/class-text.php
@@ -40,10 +40,10 @@ class Text extends Control_Abstract {
 		$this->settings[] = new Control_Setting(
 			array(
 				'name'     => 'help',
-				'label'    => __( 'Field instructions', 'block-lab' ),
-				'type'     => 'textarea',
+				'label'    => __( 'Help Text', 'block-lab' ),
+				'type'     => 'text',
 				'default'  => '',
-				'sanitize' => 'sanitize_textarea_field',
+				'sanitize' => 'sanitize_text_field',
 			)
 		);
 		$this->settings[] = new Control_Setting(

--- a/php/blocks/controls/class-textarea.php
+++ b/php/blocks/controls/class-textarea.php
@@ -40,10 +40,10 @@ class Textarea extends Control_Abstract {
 		$this->settings[] = new Control_Setting(
 			array(
 				'name'     => 'help',
-				'label'    => __( 'Field instructions', 'block-lab' ),
-				'type'     => 'textarea',
+				'label'    => __( 'Help Text', 'block-lab' ),
+				'type'     => 'text',
 				'default'  => '',
-				'sanitize' => 'sanitize_textarea_field',
+				'sanitize' => 'sanitize_text_field',
 			)
 		);
 		$this->settings[] = new Control_Setting(

--- a/php/blocks/controls/class-toggle.php
+++ b/php/blocks/controls/class-toggle.php
@@ -46,10 +46,10 @@ class Toggle extends Control_Abstract {
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( array(
 			'name'     => 'help',
-			'label'    => __( 'Field instructions', 'block-lab' ),
-			'type'     => 'textarea',
+			'label'    => __( 'Help Text', 'block-lab' ),
+			'type'     => 'text',
 			'default'  => '',
-			'sanitize' => 'sanitize_textarea_field',
+			'sanitize' => 'sanitize_text_field',
 		) );
 		$this->settings[] = new Control_Setting( array(
 			'name'     => 'default',

--- a/php/blocks/controls/class-url.php
+++ b/php/blocks/controls/class-url.php
@@ -40,10 +40,10 @@ class URL extends Control_Abstract {
 		$this->settings[] = new Control_Setting(
 			array(
 				'name'     => 'help',
-				'label'    => __( 'Field instructions', 'block-lab' ),
-				'type'     => 'textarea',
+				'label'    => __( 'Help Text', 'block-lab' ),
+				'type'     => 'text',
 				'default'  => '',
-				'sanitize' => 'sanitize_textarea_field',
+				'sanitize' => 'sanitize_text_field',
 			)
 		);
 		$this->settings[] = new Control_Setting(


### PR DESCRIPTION
@RobStino For your UX consideration.

This PR changes the Field Instructions textarea that comes with every field so that it's a standard text input instead. It also changes the label from "Field instructions" to "Help Text".

Reason:
- 90% (or more) of "Field instructions" will be short, one sentence
- This encourages users to keep the instructions brief
- Significantly reduces the amount of space taken up by field settings
- The label "Help Text" is a better description (and it's capitalised like the other labels)