### PR TITLE
Fix echoed output for unset string value

### DIFF
--- a/php/helpers.php
+++ b/php/helpers.php
@@ -38,6 +38,9 @@ function block_field( $name, $echo = true ) {
 	// Cast block value as correct type.
 	if ( isset( $block_lab_config['fields'][ $name ]['type'] ) ) {
 		switch ( $block_lab_config['fields'][ $name ]['type'] ) {
+			case 'string':
+				$value = strval( $value );
+				break;
 			case 'boolean':
 				if ( 1 === $value ) {
 					$value = true;


### PR DESCRIPTION
This should fix the word "No" being output for unset fields.