### PR TITLE
Allow negative values for number and range controls

### DIFF
--- a/php/blocks/controls/class-control-abstract.php
+++ b/php/blocks/controls/class-control-abstract.php
@@ -170,7 +170,7 @@ abstract class Control_Abstract {
 	}
 
 	/**
-	 * Render number settings
+	 * Render number settings.
 	 *
 	 * @param Control_Setting $setting The Control_Setting being rendered.
 	 * @param string          $name    The name attribute of the option.
@@ -179,13 +179,41 @@ abstract class Control_Abstract {
 	 * @return void
 	 */
 	public function render_settings_number( $setting, $name, $id ) {
+		$this->render_number( $setting, $name, $id );
+	}
+
+	/**
+	 * Render the number settings, forcing the number in the <input> to be non-negative.
+	 * This could be 0, 1, 2, etc, but not -1.
+	 *
+	 * @param Control_Setting $setting The Control_Setting being rendered.
+	 * @param string          $name    The name attribute of the option.
+	 * @param string          $id      The id attribute of the option.
+	 *
+	 * @return void
+	 */
+	public function render_settings_number_non_negative( $setting, $name, $id ) {
+		$this->render_number( $setting, $name, $id, true );
+	}
+
+	/**
+	 * Render the number settings, optionally outputting a min="0" attribute to enforce a non-negative value.
+	 *
+	 * @param Control_Setting $setting      The Control_Setting being rendered.
+	 * @param string          $name         The name attribute of the option.
+	 * @param string          $id           The id attribute of the option.
+	 * @param bool            $non_negative Whether to force the number to be non-negative via a min="0" attribute.
+	 *
+	 * @return void
+	 */
+	public function render_number( $setting, $name, $id, $non_negative = false ) {
 		?>
 		<input
 			name="<?php echo esc_attr( $name ); ?>"
 			type="number"
 			id="<?php echo esc_attr( $id ); ?>"
 			class="regular-text"
-			min="0"
+			<?php echo $non_negative ? 'min="0"' : ''; ?>
 			value="<?php echo esc_attr( $setting->get_value() ); ?>" />
 		<?php
 	}

--- a/php/blocks/controls/class-range.php
+++ b/php/blocks/controls/class-range.php
@@ -68,7 +68,7 @@ class Range extends Control_Abstract {
 		$this->settings[] = new Control_Setting( array(
 			'name'     => 'step',
 			'label'    => __( 'Step Size', 'block-lab' ),
-			'type'     => 'number',
+			'type'     => 'number_non_negative',
 			'default'  => 1,
 			'sanitize' => array( $this, 'sanitize_number' ),
 		) );

--- a/php/blocks/controls/class-text.php
+++ b/php/blocks/controls/class-text.php
@@ -68,7 +68,7 @@ class Text extends Control_Abstract {
 			array(
 				'name'     => 'maxlength',
 				'label'    => __( 'Character Limit', 'block-lab' ),
-				'type'     => 'number',
+				'type'     => 'number_non_negative',
 				'default'  => '',
 				'sanitize' => array( $this, 'sanitize_number' ),
 			)

--- a/php/blocks/controls/class-textarea.php
+++ b/php/blocks/controls/class-textarea.php
@@ -68,7 +68,7 @@ class Textarea extends Control_Abstract {
 			array(
 				'name'     => 'maxlength',
 				'label'    => __( 'Character Limit', 'block-lab' ),
-				'type'     => 'number',
+				'type'     => 'number_non_negative',
 				'default'  => '',
 				'sanitize' => array( $this, 'sanitize_number' ),
 			)

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,7 +13,7 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 }
 
 // Give access to tests_add_filter() function.
-require_once 'includes/functions.php';
+require_once $_tests_dir . '/includes/functions.php';
 
 /**
  * Manually load the plugin being tested.
@@ -26,4 +26,4 @@ function _manually_load_plugin() {
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 // Start up the WP testing environment.
-require 'includes/bootstrap.php';
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/php/blocks/controls/test-class-control-abstract.php
+++ b/tests/php/blocks/controls/test-class-control-abstract.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Tests for class Control_Abstract.
+ *
+ * @package Block_Lab
+ */
+
+use Block_Lab\Blocks\Controls;
+
+/**
+ * Tests for class Control_Abstract.
+ */
+class Test_Control_Abstract extends \WP_UnitTestCase {
+
+	/*
+	 * A mock name of the control.
+	 *
+	 * @var string
+	 */
+	const NAME = 'block-fields-settings[5c6c6bcf03d2c][default]';
+
+	/*
+	 * A mock ID of the control.
+	 *
+	 * @var string
+	 */
+	const ID = 'block-fields-edit-settings-number-default_5c6c6bcf03d2c';
+
+	/**
+	 * Instance of the extending class Number.
+	 *
+	 * @var Controls\Number
+	 */
+	public $instance;
+
+	/**
+	 * Instance of the setting.
+	 *
+	 * @var Controls\Control_setting
+	 */
+	public $setting;
+
+	/**
+	 * Setup.
+	 *
+	 * @inheritdoc
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->instance = new Controls\Number();
+		$this->setting  = new Controls\Control_Setting();
+	}
+
+	/**
+	 * Test render_settings_number().
+	 *
+	 * @covers render_settings_number.
+	 */
+	public function test_render_settings_number() {
+		ob_start();
+		$this->instance->render_settings_number( $this->setting, self::NAME, self::ID );
+		$output = ob_get_clean();
+
+		// This should not have a min="0" attribute.
+		$this->assertNotContains( 'min="0"', $output );
+		$this->assertContains( self::NAME, $output );
+		$this->assertContains( self::ID, $output );
+	}
+
+	/**
+	 * Test render_settings_number_non_negative().
+	 *
+	 * @covers render_settings_number_non_negative.
+	 */
+	public function test_render_settings_number_non_negative() {
+		ob_start();
+		$this->instance->render_settings_number_non_negative( $this->setting, self::NAME, self::ID );
+		$output = ob_get_clean();
+
+		// This should have a min="0" attribute.
+		$this->assertContains( 'min="0"', $output );
+		$this->assertContains( self::NAME, $output );
+		$this->assertContains( self::ID, $output );
+	}
+
+	/**
+	 * Test render_number().
+	 *
+	 * @covers Plugin::render_number().
+	 */
+	public function test_render_number() {
+		$min_attribute = 'min="0"';
+		ob_start();
+		$this->instance->render_number( $this->setting, self::NAME, self::ID );
+		$output = ob_get_clean();
+
+		// This should not have a min="0" attribute, as there is no 4th argument.
+		$this->assertNotContains( $min_attribute, $output );
+
+		ob_start();
+		$this->instance->render_number( $this->setting, self::NAME, self::ID, true );
+		$output = ob_get_clean();
+
+		// This should  have a min="0" attribute, as the 4th argument is true.
+		$this->assertContains( $min_attribute, $output );
+	}
+}


### PR DESCRIPTION
* Allows negative values in the Number and Range controls
* Still forces non-negative values for other controls, like for the Text control character limit, and the Range control step (interval between values).

# Before
The Range doesn't accept negative values
![range-before](https://user-images.githubusercontent.com/4063887/53049079-e929a680-345b-11e9-9b93-03b6e5eded90.gif)

# After
The Range accepts negative values

![range-before-after](https://user-images.githubusercontent.com/4063887/53048945-951ec200-345b-11e9-93c6-d4c45082c4f8.gif)

Closes #216 