### PR TITLE
In the Textarea control, add a setting for the number of rows

### DIFF
--- a/js/blocks/controls/textarea.js
+++ b/js/blocks/controls/textarea.js
@@ -8,6 +8,7 @@ const BlockLabTextareaControl = ( props, field, block ) => {
 			label={field.label}
 			placeholder={field.placeholder || ''}
 			maxLength={field.maxlength}
+			rows={field.number_rows}
 			help={field.help}
 			defaultValue={field.default}
 			value={attr[ field.name ]}

--- a/php/blocks/controls/class-textarea.php
+++ b/php/blocks/controls/class-textarea.php
@@ -73,5 +73,14 @@ class Textarea extends Control_Abstract {
 				'sanitize' => array( $this, 'sanitize_number' ),
 			)
 		);
+		$this->settings[] = new Control_Setting(
+			array(
+				'name'     => 'number_rows',
+				'label'    => __( 'Number of Rows', 'block-lab' ),
+				'type'     => 'number_non_negative',
+				'default'  => 4,
+				'sanitize' => array( $this, 'sanitize_number' ),
+			)
+		);
 	}
 }

--- a/tests/php/blocks/controls/test-class-textarea.php
+++ b/tests/php/blocks/controls/test-class-textarea.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Tests for class Textarea.
+ *
+ * @package Block_Lab
+ */
+
+use Block_Lab\Blocks\Controls;
+
+/**
+ * Tests for class Textarea.
+ */
+class Test_Textarea extends \WP_UnitTestCase {
+
+	/**
+	 * Instance of Textarea.
+	 *
+	 * @var Controls\Textarea
+	 */
+	public $instance;
+
+	/**
+	 * Setup.
+	 *
+	 * @inheritdoc
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->instance = new Controls\Textarea();
+	}
+
+	/**
+	 * Test __construct().
+	 *
+	 * @covers __construct.
+	 */
+	public function test_construct() {
+		$this->assertEquals( 'Textarea', $this->instance->label );
+		$this->assertEquals( 'textarea', $this->instance->name );
+	}
+
+	/**
+	 * Test register_settings().
+	 *
+	 * @covers Textarea::register_settings().
+	 */
+	public function test_register_settings() {
+		$this->instance->register_settings();
+		foreach ( $this->instance->settings as $setting ) {
+			$this->assertEquals( 'Block_Lab\Blocks\Controls\Control_Setting', get_class( $setting ) );
+		}
+
+		$rows_setting = end( $this->instance->settings );
+		$this->assertEquals( 'number_rows', $rows_setting->name );
+		$this->assertEquals( 'Number of Rows', $rows_setting->label );
+		$this->assertEquals( 'number_non_negative', $rows_setting->type );
+		$this->assertEquals( 4, $rows_setting->default );
+		$this->assertEquals( array( $this->instance, 'sanitize_number' ), $rows_setting->sanitize );
+	}
+}


### PR DESCRIPTION
* In the Textarea control, this adds a "Number of Rows" setting
* The default is 4, as requested in #225
* This will also be forced to be non-negative.

# New setting for the number of rows
<img width="1140" alt="textarea-8-rows" src="https://user-images.githubusercontent.com/4063887/53069124-7bec3480-34a0-11e9-93d5-253330a7a762.png">

# This number appears in the block editor
<img width="1436" alt="textarea-rows" src="https://user-images.githubusercontent.com/4063887/53069157-91615e80-34a0-11e9-953a-f5458a622ff6.png">

Closes #225