### PR TITLE
Multiselect bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,9 @@ package-lock.json
 # Ansible
 *.retry
 
+# ack
+.ackrc
+
 # Composer
 composer.lock
 vendor

--- a/js/blocks/controls/multiselect.js
+++ b/js/blocks/controls/multiselect.js
@@ -6,7 +6,7 @@ const BlockLabMultiselectControl = ( props, field, block ) => {
 
 	return (
 		<SelectControl
-			multiple="true"
+			multiple="multiple"
 			label={field.label}
 			help={field.help}
 			value={attr[ field.name ] || field.default}

--- a/js/blocks/controls/multiselect.js
+++ b/js/blocks/controls/multiselect.js
@@ -9,7 +9,7 @@ const BlockLabMultiselectControl = ( props, field, block ) => {
 			multiple="multiple"
 			label={field.label}
 			help={field.help}
-			value={attr[ field.name ] || field.default}
+			value={attr[ field.name ] || field.default_options}
 			options={field.options}
 			onChange={multiselectControl => {
 				attr[ field.name ] = multiselectControl

--- a/js/blocks/controls/multiselect.js
+++ b/js/blocks/controls/multiselect.js
@@ -9,7 +9,7 @@ const BlockLabMultiselectControl = ( props, field, block ) => {
 			multiple="multiple"
 			label={field.label}
 			help={field.help}
-			value={attr[ field.name ] || field.default_options}
+			value={attr[ field.name ] || field.default}
 			options={field.options}
 			onChange={multiselectControl => {
 				attr[ field.name ] = multiselectControl

--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -153,12 +153,18 @@ class Loader extends Component_Abstract {
 				$attributes[ $field_name ]['type'] = 'string';
 			}
 
-			if ( 'array' === $field['type'] ) {
-				$attributes[ $field_name ]['items'] = array( 'type' => 'string' );
-			}
-
 			if ( ! empty( $field['default'] ) ) {
 				$attributes[ $field_name ]['default'] = $field['default'];
+			}
+
+			if ( 'array' === $field['type'] ) {
+				/**
+				 * This is a workaround to allow empty array values. We unset the default value before registering the
+				 * block so that the default isn't used to auto-correct empty arrays. This allows the default to be
+				 * used only when creating the form.
+				 */
+				unset( $attributes[ $field_name ]['default'] );
+				$attributes[ $field_name ]['items'] = array( 'type' => 'string' );
 			}
 
 			if ( ! empty( $field['source'] ) ) {
@@ -191,8 +197,6 @@ class Loader extends Component_Abstract {
 	 */
 	public function render_block_template( $block, $attributes ) {
 		global $block_lab_attributes, $block_lab_config;
-		$block_lab_attributes = $attributes;
-		$block_lab_config     = $block;
 
 		$type = 'block';
 
@@ -202,6 +206,22 @@ class Loader extends Component_Abstract {
 		if ( 'edit' === $context ) {
 			$type = array( 'preview', 'block' );
 		}
+
+		if ( 'edit' !== $context ) {
+			/**
+			 * The block has been added, but its values weren't saved (not even the defaults). This is a phenomenon
+			 * unique to frontend output, as the editor fetches is attributes from the form fields themselves.
+			 */
+			$missing_schema_attributes = array_diff_key( $block['fields'], $attributes );
+			foreach ( $missing_schema_attributes as $attribute_name => $schema ) {
+				if ( isset( $schema['default'] ) ) {
+					$attributes[ $attribute_name ] = $schema['default'];
+				}
+			}
+		}
+
+		$block_lab_attributes = $attributes;
+		$block_lab_config     = $block;
 
 		ob_start();
 		block_lab_template_part( $block['name'], $type );

--- a/php/blocks/controls/class-multiselect.php
+++ b/php/blocks/controls/class-multiselect.php
@@ -69,14 +69,10 @@ class Multiselect extends Control_Abstract {
 				'sanitize' => array( $this, 'sanitize_textarea_assoc_array' ),
 			)
 		);
-		/**
-		 * This Setting is intentionally not named default, like other Settings. This is to allow empty array values.
-		 * By not providing a default setting, empty arrays aren't auto-corrected by the prepare_attributes_for_render
-		 * method of WP_Block_Type.
-		 */
+
 		$this->settings[] = new Control_Setting(
 			array(
-				'name'     => 'default_options',
+				'name'     => 'default',
 				'label'    => __( 'Default Value', 'block-lab' ),
 				'type'     => 'textarea_array',
 				'default'  => '',

--- a/php/blocks/controls/class-multiselect.php
+++ b/php/blocks/controls/class-multiselect.php
@@ -69,9 +69,14 @@ class Multiselect extends Control_Abstract {
 				'sanitize' => array( $this, 'sanitize_textarea_assoc_array' ),
 			)
 		);
+		/**
+		 * This Setting is intentionally not named default, like other Settings. This is to allow empty array values.
+		 * By not providing a default setting, empty arrays aren't auto-corrected by the prepare_attributes_for_render
+		 * method of WP_Block_Type.
+		 */
 		$this->settings[] = new Control_Setting(
 			array(
-				'name'     => 'default',
+				'name'     => 'default_options',
 				'label'    => __( 'Default Value', 'block-lab' ),
 				'type'     => 'textarea_array',
 				'default'  => '',

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -50,7 +50,11 @@ function block_field( $name, $echo = true ) {
 				$value = intval( $value );
 				break;
 			case 'array':
-				$value = (array) $value;
+				if ( ! $value ) {
+					$value = array();
+				} else {
+					$value = (array) $value;
+				}
 				break;
 		}
 	}


### PR DESCRIPTION
Several bug fixes included here. Closes #195. Closes #212. Most important though is the bug where unsaved blocks weren't displaying the default values.

To test:

1. Create a new block containing:
    - A multi select with a default value
    - A Text control with a default value
2. Create a new post
3. Add the block, and click out of it immediately without changing any values
4. Add the block again, and set the values of both controls to empty
5. Add the block again, and set the values of both controls to something different

You should observe:

1. In the editor, the first block shows the default values
2. On the frontend, the first block shows the default values
3. In the editor, the second block shows empty values (an empty array for the multiselect)
4. On the frontend, the second block shows empty values (an empty array for the multiselect)
5. In the editor, the third block shows your custom values
6. On the frontend, the third block shows your custom values
