### PR TITLE
Remove the placeholder for the Post control

### DIFF
--- a/js/blocks/controls/post.js
+++ b/js/blocks/controls/post.js
@@ -38,7 +38,6 @@ const BlockLabPostControl = ( props, field, block ) => {
 	return (
 		<FetchInput
 			field={field}
-			placeholder={field.placeholder}
 			apiSlug={field.post_type_rest_slug}
 			value={postAttribute['id'] }
 			displayValue={postAttribute['name']}

--- a/php/blocks/controls/class-post.php
+++ b/php/blocks/controls/class-post.php
@@ -53,15 +53,6 @@ class Post extends Control_Abstract {
 		);
 		$this->settings[] = new Control_Setting(
 			array(
-				'name'     => 'placeholder',
-				'label'    => __( 'Placeholder Text', 'block-lab' ),
-				'type'     => 'text',
-				'default'  => '',
-				'sanitize' => 'sanitize_text_field',
-			)
-		);
-		$this->settings[] = new Control_Setting(
-			array(
 				'name'     => 'post_type_rest_slug',
 				'label'    => __( 'Post Type', 'block-lab' ),
 				'type'     => 'post_type_rest_slug',


### PR DESCRIPTION
* The placeholder isn't meaningful for the Post control
* The value that displays in the `<input>` is only the post title.
* It also stores a post ID, which there's no way of adding via the placeholder field.