### PR TITLE
[WIP] Additional CSS Class support

### DIFF
--- a/js/blocks/data.js
+++ b/js/blocks/data.js
@@ -1,0 +1,66 @@
+const { data, apiFetch } = wp;
+const { registerStore } = data;
+
+const DEFAULT_STATE = {
+	notices: {},
+};
+
+const actions = {
+	setStatus( notice, status ) {
+		return {
+			type: 'SET_STATUS',
+			notice,
+			status
+		};
+	},
+	fetchFromAPI( notice ) {
+		return {
+			type: 'FETCH_FROM_API',
+			notice,
+		};
+	},
+};
+
+registerStore( 'block-lab', {
+	reducer( state = DEFAULT_STATE, action ) {
+		switch ( action.type ) {
+			case 'SET_STATUS':
+				apiFetch({
+					path: '/block-lab/v1/notices/' + action.notice,
+					method: 'PUT',
+					data: { 'status': action.status }
+				});
+				return {
+					...state,
+					notices: {
+						...state.notices,
+						[ action.notice ]: action.status,
+					},
+				};
+		}
+
+		return state;
+	},
+
+	actions,
+
+	selectors: {
+		getNotice( state, notice ) {
+			const { notices } = state;
+			return notices[ notice ];
+		},
+	},
+
+	controls: {
+		FETCH_FROM_API( action ) {
+			return apiFetch( { path: '/block-lab/v1/notices/' + action.notice } );
+		},
+	},
+
+	resolvers: {
+		* getNotice( notice ) {
+			const status = yield actions.fetchFromAPI( notice );
+			return actions.setStatus( notice, status );
+		},
+	},
+} );

--- a/js/blocks/index.js
+++ b/js/blocks/index.js
@@ -1,5 +1,8 @@
 // Import localization. Need to import for global context.
 import './i18n'
 
+// Import data.
+import './data'
+
 // Import Block Lab loader.
 import './loader'

--- a/js/blocks/loader/advanced.js
+++ b/js/blocks/loader/advanced.js
@@ -1,0 +1,43 @@
+const { Notice } = wp.components;
+const { InspectorAdvancedControls } = wp.editor;
+const { select, dispatch } = wp.data;
+const { __ } = wp.i18n;
+
+const ADDITIONAL_CSS_NOTICE_ID = 'additional_css_class';
+
+const removeNotice = ( event ) => {
+	event.currentTarget.parentNode.remove()
+	dispatch( 'block-lab' ).setStatus( ADDITIONAL_CSS_NOTICE_ID, 'dismissed' );
+}
+
+const advancedControls = () => {
+
+	const notice = () => {
+		let status = select( 'block-lab' ).getNotice( ADDITIONAL_CSS_NOTICE_ID );
+
+		if ( 'dismissed' === status ) {
+			return
+		}
+
+		return (
+			<Notice
+				status="info"
+				isDismissible={true}
+				onRemove={ removeNotice }
+				id="bl-inspector-notice"
+				className="bl-inspector-notice"
+			>
+				<p>{sprintf( __( 'Include the Additional CSS Class in a block template by using this field:', 'block-lab' ), '' )}<br /><code>className</code></p>
+				<p><a href="https://github.com/getblocklab/block-lab/wiki/7.-FAQ" target="_blank">{__( 'Read more', 'block-lab' )}</a></p>
+			</Notice>
+		)
+	}
+
+	return(
+		<InspectorAdvancedControls>
+			{notice}
+		</InspectorAdvancedControls>
+	)
+}
+
+export default advancedControls

--- a/js/blocks/loader/advanced.js
+++ b/js/blocks/loader/advanced.js
@@ -27,7 +27,7 @@ const advancedControls = () => {
 				id="bl-inspector-notice"
 				className="bl-inspector-notice"
 			>
-				<p>{sprintf( __( 'Include the Additional CSS Class in a block template by using this field:', 'block-lab' ), '' )}<br /><code>className</code></p>
+				<p>{__( 'Include the Additional CSS Class in a block template by using this field:', 'block-lab' )}<br /><code>className</code></p>
 				<p><a href="https://github.com/getblocklab/block-lab/wiki/7.-FAQ" target="_blank">{__( 'Read more', 'block-lab' )}</a></p>
 			</Notice>
 		)

--- a/js/blocks/loader/edit.js
+++ b/js/blocks/loader/edit.js
@@ -4,9 +4,10 @@ import { simplifiedFields } from "./fields";
 import icons from '../../../assets/icons.json';
 
 const { applyFilters } = wp.hooks;
+const { Notice } = wp.components;
 
 const { __ } = wp.i18n;
-const { ServerSideRender } = wp.editor;
+const { ServerSideRender, InspectorAdvancedControls } = wp.editor;
 
 const formControls = ( props, block ) => {
 
@@ -16,7 +17,7 @@ const formControls = ( props, block ) => {
 		if ( !field.location || !field.location.includes( 'editor' ) ) {
 			return null
 		}
-		
+
 		const loadedControls = applyFilters( 'block_lab_controls', controls );
 		const controlFunction = field.controlFunction || loadedControls[ field.control ];
 		const control = typeof controlFunction !== 'undefined' ? controlFunction( props, field, block ) : null;
@@ -61,6 +62,12 @@ const editComponent = ( props, block ) => {
 				)}
 			</div>
 		),
+		<InspectorAdvancedControls>
+			<Notice className="bl-inspector-notice">
+				<p><strong>Note:</strong> The Additional CSS Class can be used in a block template using the field <code>className</code>.</p>
+				<p><a href="#">Read More</a></p>
+			</Notice>
+		</InspectorAdvancedControls>
 	]
 }
 

--- a/js/blocks/loader/edit.js
+++ b/js/blocks/loader/edit.js
@@ -1,13 +1,11 @@
 import inspectorControls from './inspector'
+import advancedControls from './advanced';
 import controls from '../controls';
 import { simplifiedFields } from "./fields";
 import icons from '../../../assets/icons.json';
 
 const { applyFilters } = wp.hooks;
-const { Notice } = wp.components;
-
-const { __ } = wp.i18n;
-const { ServerSideRender, InspectorAdvancedControls } = wp.editor;
+const { ServerSideRender } = wp.editor;
 
 const formControls = ( props, block ) => {
 
@@ -62,12 +60,7 @@ const editComponent = ( props, block ) => {
 				)}
 			</div>
 		),
-		<InspectorAdvancedControls>
-			<Notice className="bl-inspector-notice">
-				<p><strong>Note:</strong> The Additional CSS Class can be used in a block template using the field <code>className</code>.</p>
-				<p><a href="#">Read More</a></p>
-			</Notice>
-		</InspectorAdvancedControls>
+		advancedControls()
 	]
 }
 

--- a/js/blocks/loader/editor.scss
+++ b/js/blocks/loader/editor.scss
@@ -254,7 +254,7 @@ div[class^="wp-block-block-lab-"] {
   }
 }
 
-.bl-inspector-notice {
+.components-notice.bl-inspector-notice {
   width: auto;
   margin: 0 -16px 1em;
   padding: 8px 36px 0 16px;
@@ -265,5 +265,9 @@ div[class^="wp-block-block-lab-"] {
       margin: 0;
       padding-bottom: 8px;
     }
+  }
+
+  >.components-notice__dismiss {
+    margin-top: 0;
   }
 }

--- a/js/blocks/loader/editor.scss
+++ b/js/blocks/loader/editor.scss
@@ -253,3 +253,17 @@ div[class^="wp-block-block-lab-"] {
     outline: none;
   }
 }
+
+.bl-inspector-notice {
+  width: auto;
+  margin: 0 -16px 1em;
+  padding: 8px 36px 0 16px;
+
+  > div {
+    margin: 0;
+    > p {
+      margin: 0;
+      padding-bottom: 8px;
+    }
+  }
+}

--- a/js/blocks/loader/index.js
+++ b/js/blocks/loader/index.js
@@ -5,7 +5,6 @@ import editComponent from './edit'
 
 import './editor.scss';
 
-const { __ } = wp.i18n;
 const { registerBlockType } = wp.blocks;
 
 const registerBlocks = () => {
@@ -24,9 +23,7 @@ const registerBlocks = () => {
 		let icon = '';
 		if ( 'undefined' !== typeof icons[ block.icon ] ) {
 			icon = (
-				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
-				     dangerouslySetInnerHTML={{ __html: icons[ block.icon ] }}
-				/>
+				<span dangerouslySetInnerHTML={{ __html: icons[ block.icon ] }} />
 			);
 		}
 

--- a/php/admin/class-admin.php
+++ b/php/admin/class-admin.php
@@ -24,6 +24,13 @@ class Admin extends Component_Abstract {
 	public $settings;
 
 	/**
+	 * User notices.
+	 *
+	 * @var Notices
+	 */
+	public $notices;
+
+	/**
 	 * Plugin license.
 	 *
 	 * @var License
@@ -50,6 +57,9 @@ class Admin extends Component_Abstract {
 	public function init() {
 		$this->settings = new Settings();
 		block_lab()->register_component( $this->settings );
+
+		$this->notices = new Notices();
+		block_lab()->register_component( $this->notices );
 
 		$this->license = new License();
 		block_lab()->register_component( $this->license );

--- a/php/admin/class-notices.php
+++ b/php/admin/class-notices.php
@@ -143,7 +143,7 @@ class Notices extends Component_Abstract {
 		}
 
 		$notices[ $notice_id ] = $status;
-return $user_id;
+
 		return update_user_meta( $user_id, $this->meta_key, $notices );
 	}
 }

--- a/php/admin/class-notices.php
+++ b/php/admin/class-notices.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Block Lab Notices.
+ *
+ * @package   Block_Lab
+ * @copyright Copyright(c) 2018, Block Lab
+ * @license   http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
+ */
+
+namespace Block_Lab\Admin;
+
+use Block_Lab\Component_Abstract;
+
+/**
+ * Class Upgrade
+ */
+class Notices extends Component_Abstract {
+
+	/**
+	 * User Meta Key.
+	 *
+	 * @var string
+	 */
+	public $meta_key = 'block-lab-notices';
+
+	/**
+	 * Register any hooks that this component needs.
+	 */
+	public function register_hooks() {
+		add_action( 'rest_api_init', array( $this, 'register_notice_endpoints' ) );
+	}
+
+	/**
+	 * Register REST API endpoint for saving dismissed notices
+	 */
+	public function register_notice_endpoints() {
+		register_rest_route(
+			'block-lab/v1',
+			'/notices/(?<id>[\w-]+)',
+			array(
+				'methods'  => \WP_REST_Server::READABLE,
+				'callback' => array( $this, 'rest_get_notice_status' ),
+			)
+		);
+
+		register_rest_route(
+			'block-lab/v1',
+			'/notices/(?<id>[\w-]+)',
+			array(
+				'methods'  => \WP_REST_Server::EDITABLE,
+				'callback' => array( $this, 'rest_update_notice_status' ),
+			)
+		);
+	}
+
+	/**
+	 * REST API Endpoint for retrieving a notice status
+	 *
+	 * @param array $request The arguments sent with the request.
+	 * @return \WP_REST_Response
+	 */
+	public function rest_get_notice_status( $request ) {
+		if ( ! isset( $request['id'] ) ) {
+			return new \WP_Error(
+				'block_lab_rest_no_id',
+				esc_html__( 'Something went horribly wrong.', 'block-lab' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$notice_status = $this->get_notice_status( $request['id'] );
+		return rest_ensure_response( $notice_status );
+	}
+
+	/**
+	 * REST API Endpoint for retrieving a notice status
+	 *
+	 * @param array $request The arguments sent with the request.
+	 * @return \WP_REST_Response
+	 */
+	public function rest_update_notice_status( $request ) {
+		if ( ! isset( $request['id'] ) || ! isset( $request['status'] ) ) {
+			return new \WP_Error(
+				'block_lab_rest_no_id',
+				esc_html__( 'Something went horribly wrong.', 'block-lab' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$update = $this->update_notice_status( $request['id'], $request['status'] );
+		return rest_ensure_response( $update );
+	}
+
+	/**
+	 * Check if a notice has been dismissed.
+	 *
+	 * @param string   $notice_id The ID of the notice to check.
+	 * @param int|bool $user_id   The ID of the user to check. Will use the current user ID if not specified.
+	 * @return string
+	 */
+	public function get_notice_status( $notice_id, $user_id = false ) {
+		if ( ! $user_id ) {
+			$user_id = get_current_user_id();
+		}
+
+		$notices = get_user_meta( $user_id, $this->meta_key, true );
+
+		if ( empty( $notices ) ) {
+			$notices = array();
+		}
+
+		if ( isset( $notices[ $notice_id ] ) ) {
+			return $notices[ $notice_id ];
+		}
+
+		return 'active';
+	}
+
+	/**
+	 * Store a dismissed notice id in user meta, so that it's not displayed again.
+	 *
+	 * @param string   $notice_id The ID of the notice to check.
+	 * @param string   $status    The status to update the notice to. Should be 'active' or 'dismissed'.
+	 * @param int|bool $user_id   The ID of the user to check. Will use the current user ID if not specified.
+	 */
+	public function update_notice_status( $notice_id, $status, $user_id = false ) {
+		if ( ! $user_id ) {
+			$user_id = get_current_user_id();
+		}
+
+		if ( 'active' !== $status && 'dismissed' !== $status ) {
+			return new \WP_Error(
+				'block_lab_invalid_status',
+				__( 'Invalid notice status. Use "active" or "dismissed".', 'block_lab' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$notices = get_user_meta( $user_id, $this->meta_key, true );
+
+		if ( empty( $notices ) ) {
+			$notices = array();
+		}
+
+		$notices[ $notice_id ] = $status;
+return $user_id;
+		return update_user_meta( $user_id, $this->meta_key, $notices );
+	}
+}

--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -152,6 +152,9 @@ class Loader extends Component_Abstract {
 			return $attributes;
 		}
 
+		// Default Editor attributes (applied to all blocks).
+		$attributes['className'] = array( 'type' => 'string' );
+
 		foreach ( $block['fields'] as $field_name => $field ) {
 			$attributes[ $field_name ] = [];
 


### PR DESCRIPTION
Fixes #253.

Docs needed.

The additional css class can be output using the `className` field.

e.g.
```
<div class="<?php block_field( 'className' ); ?>">
```

I played around with including an information notice that looks like this:
![Screen Shot 2019-04-23 at 2 04 02 pm](https://user-images.githubusercontent.com/1097667/56553242-254ec400-65d1-11e9-95a6-444c6313ef4d.png)

… but I couldn't get the "Remove" working. @kienstra @RobStino what do you think about the notice? Would it be okay to simply include information in our docs without explicitly telling the user?