### PR TITLE
Change User control to store an object, like the Post control

### DIFF
--- a/js/blocks/controls/user.js
+++ b/js/blocks/controls/user.js
@@ -3,18 +3,34 @@ import FetchInput from './fetch-input';
 const BlockLabUserControl = ( props, field, block ) => {
 	const { setAttributes } = props;
 	const attr = { ...props.attributes };
-	const getValueFromAPI = apiResponse => apiResponse.slug ? apiResponse.slug : apiResponse;
+	const DEFAULT_ID = 0;
+	const getIdFromAPI = apiResponse => ( apiResponse && apiResponse.id ) ? apiResponse.id : DEFAULT_ID;
+	const getNameFromAPI = apiResponse => ( apiResponse && apiResponse.name ) ? apiResponse.name : '';
+
+	attr[ field.name ] = Object.assign( { id: DEFAULT_ID, userName: '' }, attr[ field.name ] );
+	const userAttribute = attr[ field.name ];
 
 	return (
 		<FetchInput
 			field={field}
 			placeholder={field.placeholder}
 			apiSlug="users"
-			value={attr[ field.name ]}
-			getValueFromAPI={getValueFromAPI}
+			value={userAttribute['id']}
+			displayValue={userAttribute['userName']}
+			getValueFromAPI={getIdFromAPI}
+			getDisplayValueFromAPI={getNameFromAPI}
 			onChange={value => {
-				attr[ field.name ] = getValueFromAPI( value )
-				setAttributes( attr )
+				if ( 'string' === typeof value ) {
+					// The value is probably from the user typing into the <input>.
+					userAttribute['userName'] = value;
+					userAttribute['id'] = DEFAULT_ID;
+				} else {
+					// The value is probably an Object, from the user selecting a link in the Popover.
+					userAttribute['userName'] = getNameFromAPI( value );
+					userAttribute['id'] = getIdFromAPI( value );
+				}
+				attr[ field.name ] = userAttribute;
+				setAttributes( attr );
 			}}
 		/>
 	);

--- a/js/blocks/controls/user.js
+++ b/js/blocks/controls/user.js
@@ -14,7 +14,6 @@ const BlockLabUserControl = ( props, field, block ) => {
 	return (
 		<FetchInput
 			field={field}
-			placeholder={field.placeholder}
 			apiSlug="users"
 			value={userAttribute['id']}
 			displayValue={userAttribute['userName']}

--- a/js/blocks/controls/user.js
+++ b/js/blocks/controls/user.js
@@ -7,7 +7,8 @@ const BlockLabUserControl = ( props, field, block ) => {
 	const getIdFromAPI = apiResponse => ( apiResponse && apiResponse.id ) ? apiResponse.id : DEFAULT_ID;
 	const getNameFromAPI = apiResponse => ( apiResponse && apiResponse.name ) ? apiResponse.name : '';
 
-	attr[ field.name ] = Object.assign( { id: DEFAULT_ID, userName: '' }, attr[ field.name ] );
+	const initialValue = ( 'object' === typeof attr[ field.name ] ) ? attr[ field.name ] : {};
+	attr[ field.name ] = Object.assign( { id: DEFAULT_ID, userName: '' }, initialValue );
 	const userAttribute = attr[ field.name ];
 
 	return (

--- a/php/blocks/controls/class-user.php
+++ b/php/blocks/controls/class-user.php
@@ -51,15 +51,6 @@ class User extends Control_Abstract {
 				'sanitize' => 'sanitize_text_field',
 			)
 		);
-		$this->settings[] = new Control_Setting(
-			array(
-				'name'     => 'placeholder',
-				'label'    => __( 'Placeholder Text', 'block-lab' ),
-				'type'     => 'text',
-				'default'  => '',
-				'sanitize' => 'sanitize_text_field',
-			)
-		);
 	}
 
 	/**

--- a/php/blocks/controls/class-user.php
+++ b/php/blocks/controls/class-user.php
@@ -22,6 +22,13 @@ class User extends Control_Abstract {
 	public $name = 'user';
 
 	/**
+	 * Field variable type.
+	 *
+	 * @var string
+	 */
+	public $type = 'object';
+
+	/**
 	 * User constructor.
 	 */
 	public function __construct() {
@@ -63,7 +70,8 @@ class User extends Control_Abstract {
 	 * @return mixed $value The value to be made available or echoed on the front-end template.
 	 */
 	public function validate( $value, $echo ) {
-		$wp_user = get_user_by( 'login', $value );
+		$wp_user = isset( $value['id'] ) ? get_user_by( 'id', $value['id'] ) : null;
+
 		if ( $echo ) {
 			return $wp_user ? $wp_user->get( 'display_name' ) : '';
 		} else {

--- a/tests/php/blocks/controls/test-class-user.php
+++ b/tests/php/blocks/controls/test-class-user.php
@@ -60,13 +60,6 @@ class Test_User extends \WP_UnitTestCase {
 		$this->assertEquals( 'text', $first_setting->type );
 		$this->assertEquals( '', $first_setting->default );
 		$this->assertEquals( 'sanitize_text_field', $first_setting->sanitize );
-
-		$user_setting = end( $this->instance->settings );
-		$this->assertEquals( 'placeholder', $user_setting->name );
-		$this->assertEquals( 'Placeholder Text', $user_setting->label );
-		$this->assertEquals( 'text', $user_setting->type );
-		$this->assertEquals( '', $user_setting->default );
-		$this->assertEquals( 'sanitize_text_field', $user_setting->sanitize );
 	}
 
 	/**

--- a/tests/php/blocks/controls/test-class-user.php
+++ b/tests/php/blocks/controls/test-class-user.php
@@ -75,13 +75,13 @@ class Test_User extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Blocks\Controls\User::validate()
 	 */
 	public function test_validate() {
-		$invalid_login    = 'notvalid';
-		$valid_login      = 'Jonas Doe';
-		$expected_wp_user = $this->factory()->user->create_and_get( array( 'user_login' => $valid_login ) );
+		$expected_wp_user = $this->factory()->user->create_and_get();
+		$valid_user_id    = $expected_wp_user->ID;
+		$invalid_user_id  = 11111111;
 
-		$this->assertEquals( false, $this->instance->validate( $invalid_login, false ) );
-		$this->assertEquals( $expected_wp_user, $this->instance->validate( $valid_login, false ) );
-		$this->assertEquals( '', $this->instance->validate( $invalid_login, true ) );
-		$this->assertEquals( $expected_wp_user->get( 'display_name' ), $this->instance->validate( $valid_login, true ) );
+		$this->assertEquals( false, $this->instance->validate( array( 'id' => $invalid_user_id ), false ) );
+		$this->assertEquals( $expected_wp_user, $this->instance->validate( array( 'id' => $valid_user_id ), false ) );
+		$this->assertEquals( '', $this->instance->validate( array( 'id' => $invalid_user_id ), true ) );
+		$this->assertEquals( $expected_wp_user->get( 'display_name' ), $this->instance->validate( array( 'id' => $valid_user_id ), true ) );
 	}
 }

--- a/tests/php/blocks/controls/test-class-user.php
+++ b/tests/php/blocks/controls/test-class-user.php
@@ -79,9 +79,13 @@ class Test_User extends \WP_UnitTestCase {
 		$valid_user_id    = $expected_wp_user->ID;
 		$invalid_user_id  = 11111111;
 
-		$this->assertEquals( false, $this->instance->validate( array( 'id' => $invalid_user_id ), false ) );
+		$this->assertFalse( $this->instance->validate( array( 'id' => $invalid_user_id ), false ) );
 		$this->assertEquals( $expected_wp_user, $this->instance->validate( array( 'id' => $valid_user_id ), false ) );
 		$this->assertEquals( '', $this->instance->validate( array( 'id' => $invalid_user_id ), true ) );
 		$this->assertEquals( $expected_wp_user->get( 'display_name' ), $this->instance->validate( array( 'id' => $valid_user_id ), true ) );
+
+		// If the value is a string, instead of the expected object, assert the proper values.
+		$this->assertFalse( $this->instance->validate( 'Example username', false ) );
+		$this->assertEquals( '', $this->instance->validate( 'Baz username', true ) );
 	}
 }

--- a/tests/php/post-types/test-class-block-post.php
+++ b/tests/php/post-types/test-class-block-post.php
@@ -92,19 +92,19 @@ class Test_Block_Post extends \WP_UnitTestCase {
 	 */
 	public function test_get_field_value() {
 		$invalid_login    = 'asdfg';
-		$valid_login      = 'John Doe';
-		$expected_wp_user = $this->factory()->user->create_and_get( array( 'user_login' => $valid_login ) );
+		$expected_wp_user = $this->factory()->user->create_and_get();
+		$valid_id         = $expected_wp_user->ID;
 		$control          = 'user';
 
 		// The 'user' control.
 		$this->assertEquals( false, $this->instance->get_field_value( $invalid_login, $control, false ) );
-		$this->assertEquals( $expected_wp_user, $this->instance->get_field_value( $valid_login, $control, false ) );
+		$this->assertEquals( $expected_wp_user, $this->instance->get_field_value( array( 'id' => $valid_id ), $control, false ) );
 		$this->assertEquals( '', $this->instance->get_field_value( $invalid_login, $control, true ) );
-		$this->assertEquals( $expected_wp_user->get( 'display_name' ), $this->instance->get_field_value( $valid_login, $control, true ) );
+		$this->assertEquals( $expected_wp_user->get( 'display_name' ), $this->instance->get_field_value( array( 'id' => $valid_id ), $control, true ) );
 
 		// Any value for the 2nd argument other than 'user' should return the passed $value unchanged.
 		$this->assertEquals( $invalid_login, $this->instance->get_field_value( $invalid_login, 'different-control', false ) );
-		$this->assertEquals( $valid_login, $this->instance->get_field_value( $valid_login, 'random-control', false ) );
+		$this->assertEquals( $valid_id, $this->instance->get_field_value( $valid_id, 'random-control', false ) );
 		$this->assertEquals( $invalid_login, $this->instance->get_field_value( $invalid_login, 'some-other-control', true ) );
 
 		$string_value  = 'Example string';


### PR DESCRIPTION
**Question About Storing As An Object**

Hi @lukecarbis,
Making this backwards-compatible was harder than I thought, though I might think of a better way.

It'll require clicking "Update" for each block (in the screenshot below), and the previous values in the block editor won't persist.

Is this PR important? As it is now, the User control stores the user slug, which is immutable. 

The only improvement in this PR is a better UI, as it shows a "nicename" in the block editor like `John Doe`, instead of the slug, like `jdoe`. 

It's an improvement, but wondering if you think it's worth a backwards-compatibility break.

Instead of storing the value as the string user slug, This stores the value as:
```js
{ 
        id: 24,
        userName: 'John Doe',
}
```

The main difference is the display of the `userName` in the block editor. Before, it was the user slug, which could be like `jdoe`. 

But this now displays the username, which could be like `John Doe`. It's what the user selected as "Display name publicly as" in `/wp-admin` > Users > Your Profile.

There's no change here in the front-end display of the template. `block_field()` still echoes the username like `John Doe`, and `block_value()` still returns the `WP_User` object.

**Backwards-Compatibility Issues**

Right now, it also requires clicking "Update" in the Block Lab UI:

<img width="1098" alt="clicking-here" src="https://user-images.githubusercontent.com/4063887/56568394-84361e00-657c-11e9-9691-a8d841af3fda.png">

This is because the logic saves the block type as `object` in that UI. This PR might be able to hack that [by parsing](https://github.com/getblocklab/block-lab/blob/739872aab54b1e1edd91b1c120bd60855c6625ff/php/blocks/class-loader.php#L84) `$this->blocks` and changing the saved value to `object`. 

Also there's no backward compatibility for the block in the block editor. It's possible to filter the `$attributes` for the `render_callback`, but [that filter](https://github.com/WordPress/wordpress-develop/blob/98e942e10c53e7edd8075fc3fe68eff289cb2db2/src/wp-includes/blocks.php#L201) doesn't have access to the field type. 

So it won't know that it's a User control, in order to change the value from a `string` to an `object`.

Thanks, Luke!

Closes #288
