### PR TITLE
Fix an issue for the Post control where block_field() does not output anything

### DIFF
--- a/php/blocks/controls/class-post.php
+++ b/php/blocks/controls/class-post.php
@@ -70,11 +70,11 @@ class Post extends Control_Abstract {
 	 * @return string|WP_Post|null $value The value to be made available or echoed on the front-end template.
 	 */
 	public function validate( $value, $echo ) {
+		$post = isset( $value['id'] ) ? get_post( $value['id'] ) : null;
 		if ( $echo ) {
-			return isset( $value['title'] ) ? $value['title'] : '';
+			return $post ? $post->post_title : '';
 		} else {
-			$post_id = isset( $value['id'] ) ? $value['id'] : 0;
-			return get_post( $post_id );
+			return $post;
 		}
 	}
 }

--- a/php/blocks/controls/class-post.php
+++ b/php/blocks/controls/class-post.php
@@ -72,7 +72,7 @@ class Post extends Control_Abstract {
 	public function validate( $value, $echo ) {
 		$post = isset( $value['id'] ) ? get_post( $value['id'] ) : null;
 		if ( $echo ) {
-			return $post ? $post->post_title : '';
+			return $post ? get_the_title( $post ) : '';
 		} else {
 			return $post;
 		}

--- a/tests/php/blocks/controls/test-class-post.php
+++ b/tests/php/blocks/controls/test-class-post.php
@@ -75,17 +75,25 @@ class Test_Post extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Blocks\Controls\Post::validate()
 	 */
 	public function test_validate() {
-		$expected_wp_post = $this->factory()->post->create_and_get();
+		$post_title       = 'Example Post';
+		$expected_wp_post = $this->factory()->post->create_and_get( array( 'post_title' => $post_title ) );
 		$valid_id         = $expected_wp_post->ID;
 		$invalid_id       = 10000000;
-		$post_title       = $expected_wp_post->post_title;
 
-		// When there's an invalid post ID, this should return null.
+		// When there's an invalid post ID and the second argument is false, this should return null.
 		$this->assertEquals( null, $this->instance->validate( array( 'id' => $invalid_id ), false ) );
 		$this->assertEquals( $expected_wp_post, $this->instance->validate( array( 'id' => $valid_id ), false ) );
 
-		// If the 'title' is empty, this should return the same empty string.
-		$this->assertEquals( '', $this->instance->validate( array( 'title' => '' ), true ) );
-		$this->assertEquals( $post_title, $this->instance->validate( array( 'title' => $post_title ), true ) );
+		// If the post ID is invalid and the second argument is true (echo), this should return an empty string.
+		$this->assertEquals( '', $this->instance->validate( array( 'id' => $invalid_id ), true ) );
+		$this->assertEquals( $post_title, $this->instance->validate( array( 'id' => $valid_id ), true ) );
+
+		// If the 'post_title' is later changed, this block should output the new post title for block_field().
+		$updated_title = 'New Example Title';
+		wp_update_post( array(
+			'ID'         => $valid_id,
+			'post_title' => $updated_title,
+		) );
+		$this->assertEquals( $updated_title, $this->instance->validate( array( 'id' => $valid_id ), true ) );
 	}
 }


### PR DESCRIPTION
* Before, `post.js` saved the post's title in the attributes [as name](https://github.com/getblocklab/block-lab/blob/739872aab54b1e1edd91b1c120bd60855c6625ff/js/blocks/controls/post.js#L49), but the `validate()` method [looks for title](https://github.com/getblocklab/block-lab/blob/739872aab54b1e1edd91b1c120bd60855c6625ff/php/blocks/controls/class-post.php#L74)
* I made a [last-minute commit](https://github.com/getblocklab/block-lab/commit/0d6928fce7ea59b9e3423f94e6878d5d0199fb35) before the last `v1.2.3` release to make it save the `post_title` as `name` in the attributes instead of `title`
* This PR fixes this issue, but also gets the `post_title` from the stored post ID. So if the post title later changes, it'll output the new title.
