### PR TITLE
Add a checkbox for the textarea field to use wpautop()

### DIFF
--- a/php/blocks/controls/class-control-abstract.php
+++ b/php/blocks/controls/class-control-abstract.php
@@ -252,128 +252,32 @@ abstract class Control_Abstract {
 	}
 
 	/**
-	 * Render a <select> of public post types.
-	 *
-	 * @param Control_Setting $setting The Control_Setting being rendered.
-	 * @param string          $name    The name attribute of the option.
-	 * @param string          $id      The id attribute of the option.
-	 *
-	 * @return void
-	 */
-	public function render_settings_post_type_rest_slug( $setting, $name, $id ) {
-		$this->render_select(
-			array(
-				'setting' => $setting,
-				'name'    => $name,
-				'id'      => $id,
-				'values'  => $this->get_post_type_rest_slugs(),
-			)
-		);
-	}
-
-	/**
-	 * Gets the REST slugs of public post types, other than 'attachment'.
-	 *
-	 * @return array {
-	 *     An associative array of the post type REST slugs.
-	 *
-	 *     @type string $rest_slug The REST slug of the post type.
-	 *     @type string $name The name of the post type.n
-	 * }
-	 */
-	public function get_post_type_rest_slugs() {
-		$post_type_rest_slugs = array();
-		foreach ( get_post_types( array( 'public' => true ) ) as $post_type ) {
-			$post_type_object = get_post_type_object( $post_type );
-			if ( ! $post_type_object || empty( $post_type_object->show_in_rest ) ) {
-				continue;
-			}
-			if ( 'attachment' === $post_type ) {
-				continue;
-			}
-			$rest_slug                          = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type;
-			$labels                             = get_post_type_labels( $post_type_object );
-			$post_type_name                     = isset( $labels->name ) ? $labels->name : $post_type;
-			$post_type_rest_slugs[ $rest_slug ] = $post_type_name;
-		}
-		return $post_type_rest_slugs;
-	}
-
-	/**
-	 * Renders a <select> of public taxonomy types.
-	 *
-	 * @param Control_Setting $setting The Control_Setting being rendered.
-	 * @param string          $name    The name attribute of the option.
-	 * @param string          $id      The id attribute of the option.
-	 *
-	 * @return void
-	 */
-	public function render_settings_taxonomy_type_rest_slug( $setting, $name, $id ) {
-		$this->render_select(
-			array(
-				'setting' => $setting,
-				'name'    => $name,
-				'id'      => $id,
-				'values'  => $this->get_taxonomy_type_rest_slugs(),
-			)
-		);
-	}
-
-	/**
 	 * Renders a <select> of the passed values.
 	 *
-	 * @param array $args {
-	 *     The arguments to render a <select> element.
+	 * @param Control_Setting $setting The Control_Setting being rendered.
+	 * @param string          $name    The name attribute of the option.
+	 * @param string          $id      The id attribute of the option.
+	 * @param array           $values {
+	 *     An associative array of the post type REST slugs.
 	 *
-	 *     @type Control_Setting $setting The Control_Setting being rendered.
-	 *     @type string          $name    The name attribute of the option.
-	 *     @type string          $id      The id attribute of the option.
-	 *     @type array           $values {
-	 *         An associative array of the post type REST slugs.
-	 *
-	 *         @type string $rest_slug The rest slug, like 'tags' for the 'post_tag' taxonomy.
-	 *         @type string $label     The label to display inside the <option>.
-	 *     }
+	 *     @type string $rest_slug The rest slug, like 'tags' for the 'post_tag' taxonomy.
+	 *     @type string $label     The label to display inside the <option>.
 	 * }
 	 *
 	 * @return void
 	 */
-	public function render_select( $args ) {
-		if ( ! isset( $args['setting'], $args['name'], $args['id'], $args['values'] ) ) {
-			return;
-		}
-
+	public function render_select( $setting, $name, $id, $values ) {
 		?>
-		<select name="<?php echo esc_attr( $args['name'] ); ?>" id="<?php echo esc_attr( $args['id'] ); ?>">
+		<select name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $id ); ?>">
 			<?php
-			foreach ( $args['values'] as $rest_slug => $label ) :
+			foreach ( $values as $value => $label ) :
 				?>
-				<option value="<?php echo esc_attr( $rest_slug ); ?>" <?php selected( $rest_slug, $args['setting']->get_value() ); ?>>
+				<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, $setting->get_value() ); ?>>
 					<?php echo esc_html( $label ); ?>
 				</option>
 			<?php endforeach; ?>
 		</select>
 		<?php
-	}
-
-	/**
-	 * Gets the REST slugs of public taxonomy types.
-	 *
-	 * @return array {
-	 *     An associative array of the post type REST slugs.
-	 *
-	 *     @type string $rest_slug The REST slug of the post type.
-	 *     @type string $name The name of the post type.
-	 * }
-	 */
-	public function get_taxonomy_type_rest_slugs() {
-		$taxonomy_rest_slugs = array();
-		foreach ( get_taxonomies( array( 'show_in_rest' => true ) ) as $taxonomy_slug ) {
-			$taxonomy_object                   = get_taxonomy( $taxonomy_slug );
-			$rest_slug                         = ! empty( $taxonomy_object->rest_base ) ? $taxonomy_object->rest_base : $taxonomy_slug;
-			$taxonomy_rest_slugs[ $rest_slug ] = $taxonomy_object->label;
-		}
-		return $taxonomy_rest_slugs;
 	}
 
 	/**
@@ -513,34 +417,4 @@ abstract class Control_Abstract {
 
 		return $value;
 	}
-
-	/**
-	 * Sanitize the post type REST slug, to ensure that it's a public post type.
-	 *
-	 * This expects the rest_base of the post type, as it's easier to pass that to apiFetch in the Post control.
-	 * So this iterates through the public post types, to find if one has the rest_base equal to $value.
-	 *
-	 * @param string $value The rest_base of the post type to sanitize.
-	 * @return string|null The sanitized rest_base of the post type, or null.
-	 */
-	public function sanitize_post_type_rest_slug( $value ) {
-		if ( array_key_exists( $value, $this->get_post_type_rest_slugs() ) ) {
-			return $value;
-		}
-		return null;
-	}
-
-	/**
-	 * Sanitize the taxonomy type REST slug, to ensure that it's registered and public.
-	 *
-	 * @param string $value The rest_base of the post type to sanitize.
-	 * @return string|null The sanitized rest_base of the post type, or null.
-	 */
-	public function sanitize_taxonomy_type_rest_slug( $value ) {
-		if ( array_key_exists( $value, $this->get_taxonomy_type_rest_slugs() ) ) {
-			return $value;
-		}
-		return null;
-	}
-
 }

--- a/php/blocks/controls/class-post.php
+++ b/php/blocks/controls/class-post.php
@@ -63,10 +63,68 @@ class Post extends Control_Abstract {
 	}
 
 	/**
+	 * Render a <select> of public post types.
+	 *
+	 * @param Control_Setting $setting The Control_Setting being rendered.
+	 * @param string          $name    The name attribute of the option.
+	 * @param string          $id      The id attribute of the option.
+	 *
+	 * @return void
+	 */
+	public function render_settings_post_type_rest_slug( $setting, $name, $id ) {
+		$post_type_slugs = $this->get_post_type_rest_slugs();
+		$this->render_select( $setting, $name, $id, $post_type_slugs );
+	}
+
+	/**
+	 * Gets the REST slugs of public post types, other than 'attachment'.
+	 *
+	 * @return array {
+	 *     An associative array of the post type REST slugs.
+	 *
+	 *     @type string $rest_slug The REST slug of the post type.
+	 *     @type string $name      The name of the post type.n
+	 * }
+	 */
+	public function get_post_type_rest_slugs() {
+		$post_type_rest_slugs = array();
+		foreach ( get_post_types( array( 'public' => true ) ) as $post_type ) {
+			$post_type_object = get_post_type_object( $post_type );
+			if ( ! $post_type_object || empty( $post_type_object->show_in_rest ) ) {
+				continue;
+			}
+			if ( 'attachment' === $post_type ) {
+				continue;
+			}
+			$rest_slug                          = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type;
+			$labels                             = get_post_type_labels( $post_type_object );
+			$post_type_name                     = isset( $labels->name ) ? $labels->name : $post_type;
+			$post_type_rest_slugs[ $rest_slug ] = $post_type_name;
+		}
+		return $post_type_rest_slugs;
+	}
+
+	/**
+	 * Sanitize the post type REST slug, to ensure that it's a public post type.
+	 *
+	 * This expects the rest_base of the post type, as it's easier to pass that to apiFetch in the Post control.
+	 * So this iterates through the public post types, to find if one has the rest_base equal to $value.
+	 *
+	 * @param string $value The rest_base of the post type to sanitize.
+	 * @return string|null The sanitized rest_base of the post type, or null.
+	 */
+	public function sanitize_post_type_rest_slug( $value ) {
+		if ( array_key_exists( $value, $this->get_post_type_rest_slugs() ) ) {
+			return $value;
+		}
+		return null;
+	}
+
+	/**
 	 * Validates the value to be made available to the front-end template.
 	 *
 	 * @param mixed $value The value to either make available as a variable or echoed on the front-end template.
-	 * @param bool  $echo Whether this will be echoed.
+	 * @param bool  $echo  Whether this will be echoed.
 	 * @return string|WP_Post|null $value The value to be made available or echoed on the front-end template.
 	 */
 	public function validate( $value, $echo ) {

--- a/php/blocks/controls/class-taxonomy.php
+++ b/php/blocks/controls/class-taxonomy.php
@@ -63,10 +63,57 @@ class Taxonomy extends Control_Abstract {
 	}
 
 	/**
+	 * Renders a <select> of public taxonomy types.
+	 *
+	 * @param Control_Setting $setting The Control_Setting being rendered.
+	 * @param string          $name    The name attribute of the option.
+	 * @param string          $id      The id attribute of the option.
+	 *
+	 * @return void
+	 */
+	public function render_settings_taxonomy_type_rest_slug( $setting, $name, $id ) {
+		$taxonomy_slugs = $this->get_taxonomy_type_rest_slugs();
+		$this->render_select( $setting, $name, $id, $taxonomy_slugs );
+	}
+
+	/**
+	 * Gets the REST slugs of public taxonomy types.
+	 *
+	 * @return array {
+	 *     An associative array of the post type REST slugs.
+	 *
+	 *     @type string $rest_slug The REST slug of the post type.
+	 *     @type string $name      The name of the post type.
+	 * }
+	 */
+	public function get_taxonomy_type_rest_slugs() {
+		$taxonomy_rest_slugs = array();
+		foreach ( get_taxonomies( array( 'show_in_rest' => true ) ) as $taxonomy_slug ) {
+			$taxonomy_object                   = get_taxonomy( $taxonomy_slug );
+			$rest_slug                         = ! empty( $taxonomy_object->rest_base ) ? $taxonomy_object->rest_base : $taxonomy_slug;
+			$taxonomy_rest_slugs[ $rest_slug ] = $taxonomy_object->label;
+		}
+		return $taxonomy_rest_slugs;
+	}
+
+	/**
+	 * Sanitize the taxonomy type REST slug, to ensure that it's registered and public.
+	 *
+	 * @param string $value The rest_base of the post type to sanitize.
+	 * @return string|null The sanitized rest_base of the post type, or null.
+	 */
+	public function sanitize_taxonomy_type_rest_slug( $value ) {
+		if ( array_key_exists( $value, $this->get_taxonomy_type_rest_slugs() ) ) {
+			return $value;
+		}
+		return null;
+	}
+
+	/**
 	 * Validates the value to be made available to the front-end template.
 	 *
 	 * @param mixed $value The value to either make available as a variable or echoed on the front-end template.
-	 * @param bool  $echo Whether this will be echoed.
+	 * @param bool  $echo  Whether this will be echoed.
 	 * @return string|WP_Term|null $value The value to be made available or echoed on the front-end template.
 	 */
 	public function validate( $value, $echo ) {

--- a/php/blocks/controls/class-textarea.php
+++ b/php/blocks/controls/class-textarea.php
@@ -22,6 +22,13 @@ class Textarea extends Control_Abstract {
 	public $name = 'textarea';
 
 	/**
+	 * Control type.
+	 *
+	 * @var string
+	 */
+	public $type = 'textarea';
+
+	/**
 	 * Textarea constructor.
 	 *
 	 * @return void
@@ -80,6 +87,15 @@ class Textarea extends Control_Abstract {
 				'type'     => 'number_non_negative',
 				'default'  => 4,
 				'sanitize' => array( $this, 'sanitize_number' ),
+			)
+		);
+		$this->settings[] = new Control_Setting(
+			array(
+				'name'     => 'should_autop',
+				'label'    => __( 'Convert newlines to p tags', 'block-lab' ),
+				'type'     => 'checkbox',
+				'default'  => '0',
+				'sanitize' => array( $this, 'sanitize_checkbox' ),
 			)
 		);
 	}

--- a/php/blocks/controls/class-textarea.php
+++ b/php/blocks/controls/class-textarea.php
@@ -91,12 +91,58 @@ class Textarea extends Control_Abstract {
 		);
 		$this->settings[] = new Control_Setting(
 			array(
-				'name'     => 'should_autop',
-				'label'    => __( 'Convert newlines to p tags', 'block-lab' ),
-				'type'     => 'checkbox',
-				'default'  => '0',
-				'sanitize' => array( $this, 'sanitize_checkbox' ),
+				'name'     => 'new_lines',
+				'label'    => __( 'New Lines', 'block-lab' ),
+				'type'     => 'new_line_format',
+				'default'  => 'autop',
+				'sanitize' => array( $this, 'sanitize_new_line_format' ),
 			)
 		);
+	}
+
+	/**
+	 * Renders a <select> of new line rendering formats.
+	 *
+	 * @param Control_Setting $setting The Control_Setting being rendered.
+	 * @param string          $name    The name attribute of the option.
+	 * @param string          $id      The id attribute of the option.
+	 *
+	 * @return void
+	 */
+	public function render_settings_new_line_format( $setting, $name, $id ) {
+		$formats = $this->get_new_line_formats();
+		$this->render_select( $setting, $name, $id, $formats );
+	}
+
+	/**
+	 * Gets the new line formats.
+	 *
+	 * @return array {
+	 *     An associative array of new line formats.
+	 *
+	 *     @type string $key    The option value to save.
+	 *     @type string $label  The label.
+	 * }
+	 */
+	public function get_new_line_formats() {
+		$formats = array(
+			'autop'  => __( 'Automatically add paragraphs', 'block-lab' ),
+			'autobr' => __( 'Automatically add line breaks', 'block-lab' ),
+			'none'   => __( 'No formatting', 'block-lab' ),
+		);
+		return $formats;
+	}
+
+	/**
+	 * Sanitize the new line format, to ensure that it's valid.
+	 *
+	 * @param string $value The format to sanitize.
+	 * @return string|null The sanitized rest_base of the post type, or null.
+	 */
+	public function sanitize_new_line_format( $value ) {
+		if ( array_key_exists( $value, $this->get_new_line_formats() ) ) {
+			return $value;
+		}
+		return null;
 	}
 }

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -43,6 +43,12 @@ function block_field( $name, $echo = true ) {
 			case 'string':
 				$value = strval( $value );
 				break;
+			case 'textarea':
+				$value = strval( $value );
+				if ( ! empty( $block_lab_config['fields'][ $name ]['should_autop'] ) ) {
+					$value = wpautop( $value );
+				}
+				break;
 			case 'boolean':
 				if ( 1 === $value ) {
 					$value = true;

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -45,8 +45,13 @@ function block_field( $name, $echo = true ) {
 				break;
 			case 'textarea':
 				$value = strval( $value );
-				if ( ! empty( $block_lab_config['fields'][ $name ]['should_autop'] ) ) {
-					$value = wpautop( $value );
+				if ( isset( $block_lab_config['fields'][ $name ]['new_lines'] ) ) {
+					if ( 'autop' === $block_lab_config['fields'][ $name ]['new_lines'] ) {
+						$value = wpautop( $value );
+					}
+					if ( 'autobr' === $block_lab_config['fields'][ $name ]['new_lines'] ) {
+						$value = nl2br( $value );
+					}
 				}
 				break;
 			case 'boolean':

--- a/tests/php/blocks/controls/test-class-control-abstract.php
+++ b/tests/php/blocks/controls/test-class-control-abstract.php
@@ -106,159 +106,25 @@ class Test_Control_Abstract extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test render_settings_post_type_rest_slug.
+	 * Test render_select.
 	 *
-	 * @covers \Block_Lab\Blocks\Controls\Control_Abstract::render_settings_post_type_rest_slug()
 	 * @covers \Block_Lab\Blocks\Controls\Control_Abstract::render_select()
 	 */
-	public function test_render_settings_post_type_rest_slug() {
-		$name = 'post_type';
-		$id   = 'bl_post_type';
-
+	public function test_render_select() {
+		$options = array(
+			'foo' => 'One',
+			'bar' => 'Two',
+			'baz' => 'Three'
+		);
 		ob_start();
-		$this->instance->render_settings_post_type_rest_slug( $this->setting, $name, $id );
+		$this->instance->render_select( $this->setting, self::NAME, self::ID, $options );
 		$output = ob_get_clean();
-		$this->assertContains( $name, $output );
-		$this->assertContains( $id, $output );
-		foreach( array( 'post', 'page' ) as $post_type ) {
-			$post_type_object = get_post_type_object( $post_type );
-			$this->assertContains( $post_type_object->rest_base, $output );
-		}
-	}
 
-	/**
-	 * Test get_post_type_rest_slugs.
-	 *
-	 * @covers \Block_Lab\Blocks\Controls\Control_Abstract::get_post_type_rest_slugs()
-	 */
-	public function test_get_post_type_rest_slugs() {
-		$this->assertEquals(
-			array(
-				'posts' => 'Posts',
-				'pages' => 'Pages',
-			),
-			$this->instance->get_post_type_rest_slugs()
-		);
-	}
-
-	/**
-	 * Test render_settings_taxonomy_type_rest_slug.
-	 *
-	 * @covers \Block_Lab\Blocks\Controls\Control_Abstract::render_settings_taxonomy_type_rest_slug()
-	 * @covers \Block_Lab\Blocks\Controls\Control_Abstract::render_select()
-	 */
-	public function render_settings_taxonomy_type_rest_slug() {
-		$name = 'post_type';
-		$id   = 'bl_post_type';
-
-		ob_start();
-		$this->instance->render_settings_taxonomy_type_rest_slug( $this->setting, $name, $id );
-		$output = ob_get_clean();
-		$this->assertContains( $name, $output );
-		$this->assertContains( $id, $output );
-		foreach( array( 'post_tag', 'category' ) as $post_type ) {
-			$post_type_object = get_post_type_object( $post_type );
-			$this->assertContains( $post_type_object->rest_base, $output );
-		}
-	}
-
-	/**
-	 * Test get_taxonomy_rest_slugs.
-	 *
-	 * @covers \Block_Lab\Blocks\Controls\Control_Abstract::get_taxonomy_rest_slugs()
-	 */
-	public function test_get_taxonomy_rest_slugs() {
-		$new_tax_slug  = 'foo-new-tax';
-		$new_tax_label = 'New Taxonomy';
-		$rest_base     = 'foo-new-taxonomies';
-
-		register_taxonomy(
-			$new_tax_slug,
-			'post',
-			array(
-				'show_in_rest' => true,
-				'label'        => $new_tax_label,
-				'rest_base'    => $rest_base,
-			)
-		);
-
-		// If a registered taxonomy doesn't have a rest_base, this should use the slug instead.
-		$new_tax_slug_without_rest_base  = 'baz-new-tax';
-		$new_tax_label_without_rest_base = 'Baz New Taxonomy';
-		register_taxonomy(
-			$new_tax_slug_without_rest_base,
-			'page',
-			array(
-				'show_in_rest' => true,
-				'label'        => $new_tax_label_without_rest_base,
-			)
-		);
-
-		$this->assertEquals(
-			array(
-				'categories'                     => 'Categories',
-				'tags'                           => 'Tags',
-				$rest_base                       => $new_tax_label,
-				$new_tax_slug_without_rest_base  => $new_tax_label_without_rest_base,
-			),
-			$this->instance->get_taxonomy_type_rest_slugs()
-		);
-	}
-
-	/**
-	 * Test sanitize_post_type_rest_slug.
-	 *
-	 * @covers \Block_Lab\Blocks\Controls\Control_Abstract::sanitize_post_type_rest_slug()
-	 */
-	public function test_sanitize_post_type_rest_slug() {
-		$invalid_post_type = 'foo_invalid_type';
-		$valid_post_type   = 'posts';
-		$this->assertEmpty( $this->instance->sanitize_post_type_rest_slug( $invalid_post_type ) );
-		$this->assertEquals( $valid_post_type, $this->instance->sanitize_post_type_rest_slug( $valid_post_type ) );
-
-		// When passed 'media' for the 'attachment' post type, this should not return anything.
-		$this->assertNull( $this->instance->sanitize_post_type_rest_slug( 'media' ) );
-
-		$testimonial_post_type_slug = 'testimonials';
-		$rest_base                  = 'testimonial';
-		register_post_type(
-			$testimonial_post_type_slug,
-			array(
-				'public'       => true,
-				'show_in_rest' => true,
-				'label'        => 'Testimonials',
-				'rest_base'    => $rest_base,
-			)
-		);
-
-		// This should recognize the rest_base of the testimonial post type, even though it's different from its slug.
-		$this->assertEquals( $rest_base, $this->instance->sanitize_post_type_rest_slug( $rest_base ) );
-	}
-
-	/**
-	 * Test sanitize_taxonomy_type_rest_slug.
-	 *
-	 * @covers \Block_Lab\Blocks\Controls\Control_Abstract::sanitize_taxonomy_type_rest_slug()
-	 */
-	public function test_sanitize_taxonomy_type_rest_slug() {
-		$invalid_taxonomy_type = 'baz_invalid_taxonomy';
-		$valid_taxonomy_type   = 'categories';
-		$this->assertEmpty( $this->instance->sanitize_taxonomy_type_rest_slug( $invalid_taxonomy_type ) );
-		$this->assertEquals( $valid_taxonomy_type, $this->instance->sanitize_taxonomy_type_rest_slug( $valid_taxonomy_type ) );
-
-		$location_taxonomy_type_slug = 'location';
-		$rest_base                   = 'locations';
-		register_taxonomy(
-			$location_taxonomy_type_slug,
-			'post',
-			array(
-				'public'       => true,
-				'show_in_rest' => true,
-				'rest_base'    => $rest_base,
-			)
-		);
-
-		// This should recognize the rest_base of the testimonial taxonomy type, even though it's different from its slug.
-		$this->assertEquals( $rest_base, $this->instance->sanitize_taxonomy_type_rest_slug( $rest_base ) );
+		$this->assertContains( 'value="foo"', $output );
+		$this->assertContains( 'value="bar"', $output );
+		$this->assertContains( 'value="baz"', $output );
+		$this->assertContains( 'One', $output );
+		$this->assertContains( 'Two', $output );
+		$this->assertContains( 'Three', $output );
 	}
 }

--- a/tests/php/blocks/controls/test-class-post.php
+++ b/tests/php/blocks/controls/test-class-post.php
@@ -70,6 +70,72 @@ class Test_Post extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test render_settings_post_type_rest_slug.
+	 *
+	 * @covers \Block_Lab\Blocks\Controls\Post::render_settings_post_type_rest_slug()
+	 * @covers \Block_Lab\Blocks\Controls\Control_Abstract::render_select()
+	 */
+	public function test_render_settings_post_type_rest_slug() {
+		$name = 'post_type';
+		$id   = 'bl_post_type';
+
+		ob_start();
+		$this->instance->render_settings_post_type_rest_slug( $this->setting, $name, $id );
+		$output = ob_get_clean();
+		$this->assertContains( $name, $output );
+		$this->assertContains( $id, $output );
+		foreach( array( 'post', 'page' ) as $post_type ) {
+			$post_type_object = get_post_type_object( $post_type );
+			$this->assertContains( $post_type_object->rest_base, $output );
+		}
+	}
+
+	/**
+	 * Test get_post_type_rest_slugs.
+	 *
+	 * @covers \Block_Lab\Blocks\Controls\Post::get_post_type_rest_slugs()
+	 */
+	public function test_get_post_type_rest_slugs() {
+		$this->assertEquals(
+			array(
+				'posts' => 'Posts',
+				'pages' => 'Pages',
+			),
+			$this->instance->get_post_type_rest_slugs()
+		);
+	}
+
+	/**
+	 * Test sanitize_post_type_rest_slug.
+	 *
+	 * @covers \Block_Lab\Blocks\Controls\Post::sanitize_post_type_rest_slug()
+	 */
+	public function test_sanitize_post_type_rest_slug() {
+		$invalid_post_type = 'foo_invalid_type';
+		$valid_post_type   = 'posts';
+		$this->assertEmpty( $this->instance->sanitize_post_type_rest_slug( $invalid_post_type ) );
+		$this->assertEquals( $valid_post_type, $this->instance->sanitize_post_type_rest_slug( $valid_post_type ) );
+
+		// When passed 'media' for the 'attachment' post type, this should not return anything.
+		$this->assertNull( $this->instance->sanitize_post_type_rest_slug( 'media' ) );
+
+		$testimonial_post_type_slug = 'testimonials';
+		$rest_base                  = 'testimonial';
+		register_post_type(
+			$testimonial_post_type_slug,
+			array(
+				'public'       => true,
+				'show_in_rest' => true,
+				'label'        => 'Testimonials',
+				'rest_base'    => $rest_base,
+			)
+		);
+
+		// This should recognize the rest_base of the testimonial post type, even though it's different from its slug.
+		$this->assertEquals( $rest_base, $this->instance->sanitize_post_type_rest_slug( $rest_base ) );
+	}
+
+	/**
 	 * Test validate.
 	 *
 	 * @covers \Block_Lab\Blocks\Controls\Post::validate()

--- a/tests/php/blocks/controls/test-class-taxonomy.php
+++ b/tests/php/blocks/controls/test-class-taxonomy.php
@@ -75,7 +75,7 @@ class Test_Taxonomy extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Blocks\Controls\Taxonomy::render_settings_taxonomy_type_rest_slug()
 	 * @covers \Block_Lab\Blocks\Controls\Control_Abstract::render_select()
 	 */
-	public function render_settings_taxonomy_type_rest_slug() {
+	public function test_render_settings_taxonomy_type_rest_slug() {
 		$name = 'post_type';
 		$id   = 'bl_post_type';
 
@@ -84,9 +84,11 @@ class Test_Taxonomy extends \WP_UnitTestCase {
 		$output = ob_get_clean();
 		$this->assertContains( $name, $output );
 		$this->assertContains( $id, $output );
+
 		foreach( array( 'post_tag', 'category' ) as $post_type ) {
-			$post_type_object = get_post_type_object( $post_type );
-			$this->assertContains( $post_type_object->rest_base, $output );
+			$taxonomy = get_taxonomy( $post_type );
+			$this->assertContains( $taxonomy->rest_base, $output );
+			$this->assertContains( $taxonomy->label, $output );
 		}
 	}
 

--- a/tests/php/blocks/controls/test-class-taxonomy.php
+++ b/tests/php/blocks/controls/test-class-taxonomy.php
@@ -70,6 +70,97 @@ class Test_Taxonomy extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test render_settings_taxonomy_type_rest_slug.
+	 *
+	 * @covers \Block_Lab\Blocks\Controls\Taxonomy::render_settings_taxonomy_type_rest_slug()
+	 * @covers \Block_Lab\Blocks\Controls\Control_Abstract::render_select()
+	 */
+	public function render_settings_taxonomy_type_rest_slug() {
+		$name = 'post_type';
+		$id   = 'bl_post_type';
+
+		ob_start();
+		$this->instance->render_settings_taxonomy_type_rest_slug( $this->setting, $name, $id );
+		$output = ob_get_clean();
+		$this->assertContains( $name, $output );
+		$this->assertContains( $id, $output );
+		foreach( array( 'post_tag', 'category' ) as $post_type ) {
+			$post_type_object = get_post_type_object( $post_type );
+			$this->assertContains( $post_type_object->rest_base, $output );
+		}
+	}
+
+	/**
+	 * Test get_taxonomy_rest_slugs.
+	 *
+	 * @covers \Block_Lab\Blocks\Controls\Taxonomy::get_taxonomy_rest_slugs()
+	 */
+	public function test_get_taxonomy_rest_slugs() {
+		$new_tax_slug  = 'foo-new-tax';
+		$new_tax_label = 'New Taxonomy';
+		$rest_base     = 'foo-new-taxonomies';
+
+		register_taxonomy(
+			$new_tax_slug,
+			'post',
+			array(
+				'show_in_rest' => true,
+				'label'        => $new_tax_label,
+				'rest_base'    => $rest_base,
+			)
+		);
+
+		// If a registered taxonomy doesn't have a rest_base, this should use the slug instead.
+		$new_tax_slug_without_rest_base  = 'baz-new-tax';
+		$new_tax_label_without_rest_base = 'Baz New Taxonomy';
+		register_taxonomy(
+			$new_tax_slug_without_rest_base,
+			'page',
+			array(
+				'show_in_rest' => true,
+				'label'        => $new_tax_label_without_rest_base,
+			)
+		);
+
+		$this->assertEquals(
+			array(
+				'categories'                     => 'Categories',
+				'tags'                           => 'Tags',
+				$rest_base                       => $new_tax_label,
+				$new_tax_slug_without_rest_base  => $new_tax_label_without_rest_base,
+			),
+			$this->instance->get_taxonomy_type_rest_slugs()
+		);
+	}
+
+	/**
+	 * Test sanitize_taxonomy_type_rest_slug.
+	 *
+	 * @covers \Block_Lab\Blocks\Controls\Taxonomy::sanitize_taxonomy_type_rest_slug()
+	 */
+	public function test_sanitize_taxonomy_type_rest_slug() {
+		$invalid_taxonomy_type = 'baz_invalid_taxonomy';
+		$valid_taxonomy_type   = 'categories';
+		$this->assertEmpty( $this->instance->sanitize_taxonomy_type_rest_slug( $invalid_taxonomy_type ) );
+		$this->assertEquals( $valid_taxonomy_type, $this->instance->sanitize_taxonomy_type_rest_slug( $valid_taxonomy_type ) );
+
+		$location_taxonomy_type_slug = 'location';
+		$rest_base                   = 'locations';
+		register_taxonomy(
+			$location_taxonomy_type_slug,
+			'post',
+			array(
+				'public'       => true,
+				'show_in_rest' => true,
+				'rest_base'    => $rest_base,
+			)
+		);
+
+		// This should recognize the rest_base of the testimonial taxonomy type, even though it's different from its slug.
+		$this->assertEquals( $rest_base, $this->instance->sanitize_taxonomy_type_rest_slug( $rest_base ) );
+	}
+
+	/**
 	 * Test validate.
 	 *
 	 * @covers \Block_Lab\Blocks\Controls\Taxonomy::validate()

--- a/tests/php/blocks/controls/test-class-textarea.php
+++ b/tests/php/blocks/controls/test-class-textarea.php
@@ -20,6 +20,13 @@ class Test_Textarea extends \WP_UnitTestCase {
 	public $instance;
 
 	/**
+	 * Instance of the setting.
+	 *
+	 * @var Controls\Control_setting
+	 */
+	public $setting;
+
+	/**
 	 * Setup.
 	 *
 	 * @inheritdoc
@@ -27,6 +34,7 @@ class Test_Textarea extends \WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->instance = new Controls\Textarea();
+		$this->setting  = new Controls\Control_Setting();
 	}
 
 	/**

--- a/tests/php/blocks/controls/test-class-textarea.php
+++ b/tests/php/blocks/controls/test-class-textarea.php
@@ -50,11 +50,18 @@ class Test_Textarea extends \WP_UnitTestCase {
 			$this->assertEquals( 'Block_Lab\Blocks\Controls\Control_Setting', get_class( $setting ) );
 		}
 
+		$rows_setting = reset( $this->instance->settings );
+		$this->assertEquals( 'help', $rows_setting->name );
+		$this->assertEquals( 'Help Text', $rows_setting->label );
+		$this->assertEquals( 'text', $rows_setting->type );
+		$this->assertEquals( '', $rows_setting->default );
+		$this->assertEquals( 'sanitize_text_field', $rows_setting->sanitize );
+
 		$rows_setting = end( $this->instance->settings );
-		$this->assertEquals( 'number_rows', $rows_setting->name );
-		$this->assertEquals( 'Number of Rows', $rows_setting->label );
-		$this->assertEquals( 'number_non_negative', $rows_setting->type );
-		$this->assertEquals( 4, $rows_setting->default );
-		$this->assertEquals( array( $this->instance, 'sanitize_number' ), $rows_setting->sanitize );
+		$this->assertEquals( 'should_autop', $rows_setting->name );
+		$this->assertEquals( 'Convert newlines to p tags', $rows_setting->label );
+		$this->assertEquals( 'checkbox', $rows_setting->type );
+		$this->assertEquals( 0, $rows_setting->default );
+		$this->assertEquals( array( $this->instance, 'sanitize_checkbox' ), $rows_setting->sanitize );
 	}
 }

--- a/tests/php/blocks/controls/test-class-textarea.php
+++ b/tests/php/blocks/controls/test-class-textarea.php
@@ -72,6 +72,9 @@ class Test_Textarea extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Blocks\Controls\Control_Abstract::render_select()
 	 */
 	public function test_render_settings_new_line_format() {
+		$name = 'textarea';
+		$id   = 'bl_textarea';
+
 		ob_start();
 		$this->instance->render_settings_new_line_format( $this->setting, $name, $id );
 		$output = ob_get_clean();
@@ -87,7 +90,6 @@ class Test_Textarea extends \WP_UnitTestCase {
 	 */
 	public function test_get_new_line_formats() {
 		$formats = $this->instance->get_new_line_formats();
-		$this->assertIsArray( $formats );
 		$this->assertArrayHasKey( 'autop', $formats );
 		$this->assertArrayHasKey( 'autobr', $formats );
 		$this->assertArrayHasKey( 'none', $formats );

--- a/tests/php/blocks/controls/test-class-textarea.php
+++ b/tests/php/blocks/controls/test-class-textarea.php
@@ -58,10 +58,50 @@ class Test_Textarea extends \WP_UnitTestCase {
 		$this->assertEquals( 'sanitize_text_field', $rows_setting->sanitize );
 
 		$rows_setting = end( $this->instance->settings );
-		$this->assertEquals( 'should_autop', $rows_setting->name );
-		$this->assertEquals( 'Convert newlines to p tags', $rows_setting->label );
-		$this->assertEquals( 'checkbox', $rows_setting->type );
-		$this->assertEquals( 0, $rows_setting->default );
-		$this->assertEquals( array( $this->instance, 'sanitize_checkbox' ), $rows_setting->sanitize );
+		$this->assertEquals( 'new_lines', $rows_setting->name );
+		$this->assertEquals( 'New Lines', $rows_setting->label );
+		$this->assertEquals( 'new_line_format', $rows_setting->type );
+		$this->assertEquals( 'autop', $rows_setting->default );
+		$this->assertEquals( array( $this->instance, 'sanitize_new_line_format' ), $rows_setting->sanitize );
+	}
+
+	/**
+	 * Test render_settings_new_line_format.
+	 *
+	 * @covers \Block_Lab\Blocks\Controls\textarea::render_settings_new_line_format()
+	 * @covers \Block_Lab\Blocks\Controls\Control_Abstract::render_select()
+	 */
+	public function test_render_settings_new_line_format() {
+		ob_start();
+		$this->instance->render_settings_new_line_format( $this->setting, $name, $id );
+		$output = ob_get_clean();
+		$this->assertContains( 'autop', $output );
+		$this->assertContains( 'autobr', $output );
+		$this->assertContains( 'none', $output );
+	}
+
+	/**
+	 * Test get_new_line_formats.
+	 *
+	 * @covers \Block_Lab\Blocks\Controls\textarea::get_new_line_formats()
+	 */
+	public function test_get_new_line_formats() {
+		$formats = $this->instance->get_new_line_formats();
+		$this->assertIsArray( $formats );
+		$this->assertArrayHasKey( 'autop', $formats );
+		$this->assertArrayHasKey( 'autobr', $formats );
+		$this->assertArrayHasKey( 'none', $formats );
+	}
+
+	/**
+	 * Test test_sanitize_new_line_format.
+	 *
+	 * @covers \Block_Lab\Blocks\Controls\Textarea::test_sanitize_new_line_format()
+	 */
+	public function test_sanitize_new_line_format() {
+		$this->assertEmpty( $this->instance->sanitize_new_line_format( 'foo' ) );
+		$this->assertEquals( 'autop', $this->instance->sanitize_new_line_format( 'autop' ) );
+		$this->assertEquals( 'autobr', $this->instance->sanitize_new_line_format( 'autobr' ) );
+		$this->assertEquals( 'none', $this->instance->sanitize_new_line_format( 'none' ) );
 	}
 }


### PR DESCRIPTION
This will enable displaying the Textarea control on the front-end like how it looks in the block editor.

Maybe I didn't understand #252 right, or I couldn't reproduce it.

But it looked like before, newlines weren't actually stripped. But multiple lines of text still appeared on one line:

<img width="959" alt="newlines-here" src="https://user-images.githubusercontent.com/4063887/57362628-1cfb9a80-7134-11e9-8f0e-ae0db12e80af.png">

This addresses that by adding a new checkbox to apply `wpautop()`:

<img width="1165" alt="new-checkbox" src="https://user-images.githubusercontent.com/4063887/57362797-65b35380-7134-11e9-9537-5740710070ef.png">

Still, we may want to just let the Rich Text control handle this (#20).

# Before
![before-not-different-lines](https://user-images.githubusercontent.com/4063887/57362393-95ae2700-7133-11e9-832d-8dc2533c649b.gif)

# After 
![after-different-lines](https://user-images.githubusercontent.com/4063887/57362434-ab235100-7133-11e9-9895-6c491c907e2f.gif)

Closes #252 