### PR TITLE
Additional CSS Class Support

### DIFF
--- a/js/blocks/loader/advanced.js
+++ b/js/blocks/loader/advanced.js
@@ -1,0 +1,29 @@
+/* global blockLab */
+
+const { InspectorAdvancedControls } = wp.editor;
+const { DotTip } = wp.nux;
+const { sprintf, __ } = wp.i18n;
+
+const inspectorControls = ( props, block ) => {
+	if ( '-1' === blockLab.authorBlocks.indexOf( block.name ) ) {
+		return;
+	}
+
+	const tip = sprintf(
+		__( 'The Additional CSS Class can be included in your block template with the %1$s field.', 'block-lab' ),
+		'<code>className</code>'
+	);
+
+	return (
+		<InspectorAdvancedControls>
+			<DotTip tipId="block-lab/additional-css-class">
+				<p className="bl-dot-tip" dangerouslySetInnerHTML={{__html: tip}}></p>
+				<p className="bl-dot-tip read-more">
+					<a href="https://github.com/getblocklab/block-lab/wiki/7.-FAQ" target="_blank">{__( 'Read more', 'block-lab' )}</a>
+				</p>
+			</DotTip>
+		</InspectorAdvancedControls>
+	)
+}
+
+export default inspectorControls

--- a/js/blocks/loader/edit.js
+++ b/js/blocks/loader/edit.js
@@ -1,11 +1,10 @@
 import inspectorControls from './inspector'
+import inspectorAdvancedControls from './advanced'
 import controls from '../controls';
 import { simplifiedFields } from "./fields";
 import icons from '../../../assets/icons.json';
 
 const { applyFilters } = wp.hooks;
-
-const { __ } = wp.i18n;
 const { ServerSideRender } = wp.editor;
 
 const formControls = ( props, block ) => {
@@ -16,7 +15,7 @@ const formControls = ( props, block ) => {
 		if ( !field.location || !field.location.includes( 'editor' ) ) {
 			return null
 		}
-		
+
 		const loadedControls = applyFilters( 'block_lab_controls', controls );
 		const controlFunction = field.controlFunction || loadedControls[ field.control ];
 		const control = typeof controlFunction !== 'undefined' ? controlFunction( props, field, block ) : null;
@@ -44,6 +43,7 @@ const editComponent = ( props, block ) => {
 
 	return [
 		inspectorControls( props, block ),
+		inspectorAdvancedControls( props, block ),
 		(
 			<div className={className} key={"form-controls-" + block.name}>
 				{isSelected ? (

--- a/js/blocks/loader/editor.scss
+++ b/js/blocks/loader/editor.scss
@@ -253,3 +253,9 @@ div[class^="wp-block-block-lab-"] {
     outline: none;
   }
 }
+
+.bl-dot-tip.read-more {
+  float: left;
+  margin: 0;
+  padding-right: 1em;
+}

--- a/js/blocks/loader/index.js
+++ b/js/blocks/loader/index.js
@@ -24,9 +24,7 @@ const registerBlocks = () => {
 		let icon = '';
 		if ( 'undefined' !== typeof icons[ block.icon ] ) {
 			icon = (
-				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
-				     dangerouslySetInnerHTML={{ __html: icons[ block.icon ] }}
-				/>
+				<span dangerouslySetInnerHTML={{ __html: icons[ block.icon ] }} />
 			);
 		}
 

--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -100,6 +100,25 @@ class Loader extends Component_Abstract {
 				$this->enqueue_block_styles( $block['name'], array( 'preview', 'block' ) );
 			}
 		}
+
+		// Used to conditionally show notices for blocks belonging to an author.
+		$author_blocks = get_posts(
+			array(
+				'author'         => get_current_user_id(),
+				'post_type'      => 'block_lab',
+				// We could use -1 here, but we'll limit it just in case somebody goes nuts with making custom blocks.
+				'posts_per_page' => 99,
+			)
+		);
+
+		$author_block_slugs = array_map(
+			function( $post ) {
+				return $post->post_name;
+			},
+			$author_blocks
+		);
+
+		wp_localize_script( 'block-lab-blocks', 'blockLab', array( 'authorBlocks' => $author_block_slugs ) );
 	}
 
 	/**

--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -171,6 +171,9 @@ class Loader extends Component_Abstract {
 			return $attributes;
 		}
 
+		// Default Editor attributes (applied to all blocks).
+		$attributes['className'] = array( 'type' => 'string' );
+
 		foreach ( $block['fields'] as $field_name => $field ) {
 			$attributes[ $field_name ] = [];
 

--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -106,17 +106,12 @@ class Loader extends Component_Abstract {
 			array(
 				'author'         => get_current_user_id(),
 				'post_type'      => 'block_lab',
-				// We could use -1 here, but we'll limit it just in case somebody goes nuts with making custom blocks.
+				// We could use -1 here, but that could be dangerous. 99 is more than enough.
 				'posts_per_page' => 99,
 			)
 		);
 
-		$author_block_slugs = array_map(
-			function( $post ) {
-				return $post->post_name;
-			},
-			$author_blocks
-		);
+		$author_block_slugs = wp_list_pluck( $author_blocks, 'post_name' );
 
 		wp_localize_script( 'block-lab-blocks', 'blockLab', array( 'authorBlocks' => $author_block_slugs ) );
 	}


### PR DESCRIPTION
This is a simple fix, but comes with our first "dot tip".

**Testing the Advanced CSS Class**
Include the following in your template:
```
<p><?php block_field( 'className' );?></p>
<p><?php echo block_value( 'className' ); ?></p>
```

**Testing the DotTip**

1. You've probably disabled tips. It's easy to do. There's an [x] button included with all tips (including the default ones that show when you first use Gutenberg). Pressing this disables all tips permanently.

<img width="637" alt="Screen Shot 2019-05-17 at 8 49 36 am" src="https://user-images.githubusercontent.com/1097667/57892022-e08d1480-7880-11e9-832c-4981947016b2.png">

To re-enable tips you've got to clear your browser cookies, or even easier, type the following into your console:
```
wp.data.dispatch( 'core/nux' ).enableTips();
```

This time clear the default tips by pressing "See next tip" > "See next tip" > "See next tip" > "Got it".

2. Add a block. It's got to be a block that you have authored – we don't show the tip on blocks that you haven't authored, so that it doesn't show up for non-block-lab blocks, and it doesn't show for editors / clients who are using your blocks.

3. Click the block to show the edit interface, then in the sidebar, open the Advanced pane. You should see something like this:

<img width="757" alt="Screen Shot 2019-05-17 at 8 48 06 am" src="https://user-images.githubusercontent.com/1097667/57892154-4da0aa00-7881-11e9-9c09-0176ebce146c.png">

Fixes #253.

Docs needed (@RobStino?)