### PR TITLE
Display a notice if a field isn't available anymore

### DIFF
--- a/css/admin.block-post.css
+++ b/css/admin.block-post.css
@@ -116,6 +116,10 @@
 #block_fields .block-fields-rows .block-fields-control span.pro-required {
 	margin-left: 0.5rem;
 }
+#block_fields .block-fields-rows input[readonly="readonly"],
+#block_fields .block-fields-rows textarea[readonly="readonly"] {
+    color: #999;
+}
 #block_fields .block-fields-rows .block-fields-edit-loading .loading:before {
 	content: '';
 	box-sizing: border-box;

--- a/css/admin.block-post.css
+++ b/css/admin.block-post.css
@@ -110,6 +110,12 @@
 #block_fields .block-fields-rows .block-fields-edit th label {
 	font-weight: 600;
 }
+#block_fields .block-fields-rows .block-fields-control {
+	display: flex;
+}
+#block_fields .block-fields-rows .block-fields-control span.pro-required {
+	margin-left: 0.5rem;
+}
 #block_fields .block-fields-rows .block-fields-edit-loading .loading:before {
 	content: '';
 	box-sizing: border-box;

--- a/php/blocks/controls/class-email.php
+++ b/php/blocks/controls/class-email.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * URL control.
+ * Email control.
  *
  * @package   Block_Lab
  * @copyright Copyright(c) 2018, Block Lab

--- a/php/blocks/controls/class-number.php
+++ b/php/blocks/controls/class-number.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * URL control.
+ * Number control.
  *
  * @package   Block_Lab
  * @copyright Copyright(c) 2018, Block Lab

--- a/php/blocks/controls/class-url.php
+++ b/php/blocks/controls/class-url.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * URL control.
+ * Url control.
  *
  * @package   Block_Lab
  * @copyright Copyright(c) 2018, Block Lab
@@ -12,7 +12,7 @@ namespace Block_Lab\Blocks\Controls;
 /**
  * Class Text
  */
-class URL extends Control_Abstract {
+class Url extends Control_Abstract {
 
 	/**
 	 * Control name.

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -543,7 +543,30 @@ class Block_Post extends Component_Abstract {
 				<code id="block-fields-name-code_<?php echo esc_attr( $uid ); ?>"><?php echo esc_html( $field->name ); ?></code>
 			</div>
 			<div class="block-fields-control" id="block-fields-control_<?php echo esc_attr( $uid ); ?>">
-				<?php echo esc_html( $this->controls[ $field->control ]->label ); ?>
+				<?php
+				if ( isset( $this->controls[ $field->control ] ) ) :
+					echo esc_html( $this->controls[ $field->control ]->label );
+				else :
+					?>
+					<div class="notice notice-info inline notice-alt">
+						<?php
+						/* translators: %1$s is the field type, %2$s is the URL for the Pro license */
+						printf(
+							wp_kses_post( 'This <code>%1$s</code> field type is not available. Maybe your <a href="%2$s">pro license</a> expired.', 'block-lab' ),
+							esc_html( $field->control ),
+							esc_url(
+								add_query_arg(
+									array(
+										'post_type' => 'block_lab',
+										'page'      => 'block-lab-pro',
+									),
+									admin_url( 'edit.php' )
+								)
+							)
+						);
+						?>
+					</div>
+				<?php endif; ?>
 			</div>
 			<div class="block-fields-location" id="block-fields-location_<?php echo esc_attr( $uid ); ?>">
 				<?php

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -548,7 +548,7 @@ class Block_Post extends Component_Abstract {
 					echo esc_html( $this->controls[ $field->control ]->label );
 				else :
 					?>
-					<div class="notice notice-info inline notice-alt">
+					<div class="notice notice-warning inline notice-alt">
 						<?php
 						/* translators: %1$s is the field type, %2$s is the URL for the Pro license */
 						printf(

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -567,7 +567,7 @@ class Block_Post extends Component_Abstract {
 				else :
 					?>
 					<span class="dashicons dashicons-warning"></span>
-					<span>
+					<span class="pro-required">
 						<?php
 						/* translators: %1$s is the field type, %2$s is the URL for the Pro license */
 						printf(

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -548,11 +548,12 @@ class Block_Post extends Component_Abstract {
 					echo esc_html( $this->controls[ $field->control ]->label );
 				else :
 					?>
-					<div class="notice notice-warning inline notice-alt">
+					<span class="dashicons dashicons-warning"></span>
+					<span>
 						<?php
 						/* translators: %1$s is the field type, %2$s is the URL for the Pro license */
 						printf(
-							wp_kses_post( 'This <code>%1$s</code> field type is not available. Maybe your <a href="%2$s">pro license</a> expired.', 'block-lab' ),
+							wp_kses_post( 'This <code>%1$s</code> field requires an active <a href="%2$s">pro license</a>.', 'block-lab' ),
 							esc_html( $field->control ),
 							esc_url(
 								add_query_arg(
@@ -565,7 +566,7 @@ class Block_Post extends Component_Abstract {
 							)
 						);
 						?>
-					</div>
+					</span>
 				<?php endif; ?>
 			</div>
 			<div class="block-fields-location" id="block-fields-location_<?php echo esc_attr( $uid ); ?>">

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -109,6 +109,7 @@ class Block_Post extends Component_Abstract {
 	/**
 	 * Gets an instantiated pro control.
 	 *
+	 * @param string $control_name The name of the pro control.
 	 * @return object The instantiated pro control.
 	 */
 	public function instantiate_pro_control( $control_name ) {

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -133,6 +133,11 @@ class Block_Post extends Component_Abstract {
 	public function get_field_value( $value, $control, $echo ) {
 		if ( isset( $this->controls[ $control ] ) && method_exists( $this->controls[ $control ], 'validate' ) ) {
 			return call_user_func( array( $this->controls[ $control ], 'validate' ), $value, $echo );
+		} elseif ( in_array( $control, $this->pro_controls, true ) && ! block_lab()->is_pro() ) {
+			$pro_control = $this->instantiate_pro_control( $control );
+			if ( method_exists( $pro_control, 'validate' ) ) {
+				return call_user_func( array( $pro_control, 'validate' ), $value, $echo );
+			}
 		}
 
 		return $value;

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -627,7 +627,8 @@ class Block_Post extends Component_Abstract {
 								class="regular-text"
 								value="<?php echo esc_attr( $field->label ); ?>"
 								data-sync="block-fields-label_<?php echo esc_attr( $uid ); ?>"
-								<?php echo $is_field_disabled ? 'readonly="readonly"' : ''; ?> />
+								<?php echo $is_field_disabled ? 'readonly="readonly"' : ''; ?>
+							/>
 							<?php if ( $is_field_disabled ) : ?>
 								<input
 									name="block-is-disabled-pro-field[<?php echo esc_attr( $uid ); ?>]"

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -120,8 +120,8 @@ class Block_Post extends Component_Abstract {
 	/**
 	 * Gets an instantiated control.
 	 *
-	 * @param string $control_name The name of the pro control.
-	 * @return object|null The instantiated pro control.
+	 * @param string $control_name The name of the control.
+	 * @return object|null The instantiated control, or null.
 	 */
 	public function get_control( $control_name ) {
 		if ( isset( $this->controls[ $control_name ] ) ) {

--- a/tests/php/post-types/test-class-block-post.php
+++ b/tests/php/post-types/test-class-block-post.php
@@ -87,6 +87,18 @@ class Test_Block_Post extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test instantiate_pro_control.
+	 *
+	 * @covers \Block_Lab\Post_Types\Block_Post::instantiate_pro_control()
+	 */
+	public function test_instantiate_pro_control() {
+		$namespace = 'Block_Lab\Blocks\Controls\\';
+		$this->assertEquals( $namespace . 'Post', get_class( $this->instance->instantiate_pro_control( 'post' ) ) );
+		$this->assertEquals( $namespace . 'Taxonomy', get_class( $this->instance->instantiate_pro_control( 'taxonomy' ) ) );
+		$this->assertEquals( $namespace . 'User', get_class( $this->instance->instantiate_pro_control( 'user' ) ) );
+	}
+
+	/**
 	 * Test get_field_value.
 	 *
 	 * @covers \Block_Lab\Post_Types\Block_Post::get_field_value()

--- a/tests/php/post-types/test-class-block-post.php
+++ b/tests/php/post-types/test-class-block-post.php
@@ -109,7 +109,33 @@ class Test_Block_Post extends \WP_UnitTestCase {
 		$valid_id         = $expected_wp_user->ID;
 		$control          = 'user';
 
+		// Simulate the pro license being active.
+		set_transient(
+			'block_lab_license',
+			array(
+				'license' => 'valid',
+				'expires' => date( '+1 month' ),
+			)
+		);
+		block_lab()->admin->init();
+		$this->instance->register_controls();
+
 		// The 'user' control.
+		$this->assertEquals( false, $this->instance->get_field_value( $invalid_login, $control, false ) );
+		$this->assertEquals( $expected_wp_user, $this->instance->get_field_value( array( 'id' => $valid_id ), $control, false ) );
+		$this->assertEquals( '', $this->instance->get_field_value( $invalid_login, $control, true ) );
+		$this->assertEquals( $expected_wp_user->get( 'display_name' ), $this->instance->get_field_value( array( 'id' => $valid_id ), $control, true ) );
+
+		// If the pro license is inactive, this should still render the pro field the same as if it's active.
+		set_transient(
+			'block_lab_license',
+			array(
+				'license' => 'expired',
+			)
+		);
+		block_lab()->admin->init();
+		$this->instance->register_controls();
+
 		$this->assertEquals( false, $this->instance->get_field_value( $invalid_login, $control, false ) );
 		$this->assertEquals( $expected_wp_user, $this->instance->get_field_value( array( 'id' => $valid_id ), $control, false ) );
 		$this->assertEquals( '', $this->instance->get_field_value( $invalid_login, $control, true ) );

--- a/tests/php/post-types/test-class-block-post.php
+++ b/tests/php/post-types/test-class-block-post.php
@@ -76,7 +76,7 @@ class Test_Block_Post extends \WP_UnitTestCase {
 		// Because the pro license isn't active, the 'user' control should not display.
 		$this->assertFalse( isset( $this->instance->controls['user'] ) );
 
-		$this->set_valid_license();
+		$this->set_license_validity( true );
 		block_lab()->admin->init();
 		$this->instance->register_controls();
 
@@ -110,13 +110,7 @@ class Test_Block_Post extends \WP_UnitTestCase {
 		$control          = 'user';
 
 		// Simulate the pro license being active.
-		set_transient(
-			'block_lab_license',
-			array(
-				'license' => 'valid',
-				'expires' => date( '+1 month' ),
-			)
-		);
+		$this->set_license_validity( true );
 		block_lab()->admin->init();
 		$this->instance->register_controls();
 
@@ -127,12 +121,7 @@ class Test_Block_Post extends \WP_UnitTestCase {
 		$this->assertEquals( $expected_wp_user->get( 'display_name' ), $this->instance->get_field_value( array( 'id' => $valid_id ), $control, true ) );
 
 		// If the pro license is inactive, this should still render the pro field the same as if it's active.
-		set_transient(
-			'block_lab_license',
-			array(
-				'license' => 'expired',
-			)
-		);
+		$this->set_license_validity( false );
 		block_lab()->admin->init();
 		$this->instance->register_controls();
 
@@ -231,16 +220,23 @@ class Test_Block_Post extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Sets a valid license.
+	 * Sets whether the license is valid or not.
+	 *
+	 * @param bool $is_valid Whether the license is valid.
 	 */
-	public function set_valid_license() {
-		set_transient(
-			'block_lab_license',
-			array(
+	public function set_license_validity( $is_valid ) {
+		if ( $is_valid ) {
+			$transient_value = array(
 				'license' => 'valid',
 				'expires' => date( '+1 month' ),
-			)
-		);
+			);
+		} else {
+			$transient_value = array(
+				'license' => 'expired',
+			);
+		}
+
+		set_transient( 'block_lab_license', $transient_value );
 	}
 
 	/**

--- a/tests/php/post-types/test-class-block-post.php
+++ b/tests/php/post-types/test-class-block-post.php
@@ -87,15 +87,18 @@ class Test_Block_Post extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test instantiate_pro_control.
+	 * Test get_control.
 	 *
-	 * @covers \Block_Lab\Post_Types\Block_Post::instantiate_pro_control()
+	 * @covers \Block_Lab\Post_Types\Block_Post::get_control()
 	 */
-	public function test_instantiate_pro_control() {
+	public function test_get_control() {
 		$namespace = 'Block_Lab\Blocks\Controls\\';
-		$this->assertEquals( $namespace . 'Post', get_class( $this->instance->instantiate_pro_control( 'post' ) ) );
-		$this->assertEquals( $namespace . 'Taxonomy', get_class( $this->instance->instantiate_pro_control( 'taxonomy' ) ) );
-		$this->assertEquals( $namespace . 'User', get_class( $this->instance->instantiate_pro_control( 'user' ) ) );
+		$this->assertEquals( $namespace . 'Post', get_class( $this->instance->get_control( 'post' ) ) );
+		$this->assertEquals( $namespace . 'Taxonomy', get_class( $this->instance->get_control( 'taxonomy' ) ) );
+		$this->assertEquals( $namespace . 'User', get_class( $this->instance->get_control( 'user' ) ) );
+
+		// If the control doesn't exist, this should return null.
+		$this->assertEquals( null, $this->instance->get_control( 'non-existant-control' ) );
 	}
 
 	/**

--- a/tests/php/test-helpers.php
+++ b/tests/php/test-helpers.php
@@ -19,16 +19,16 @@ class Test_Helpers extends \WP_UnitTestCase {
 		global $block_lab_attributes, $block_lab_config;
 
 		$field_name                          = 'test-user';
-		$mock_login                          = 'mock-user-login';
-		$block_lab_attributes[ $field_name ] = $mock_login;
+		$mock_text                           = 'Example text';
+		$block_lab_attributes[ $field_name ] = $mock_text;
 
-		$block_lab_config['fields'][ $field_name ]['control'] = 'user';
+		$block_lab_config['fields'][ $field_name ]['control'] = 'text';
 
 		// Because block_field() had the second argument of false, this should return the value stored in the field, not echo it.
 		ob_start();
 		$return_value = block_field( $field_name, false );
 		$echoed       = ob_get_clean();
-		$this->assertEquals( $mock_login, $return_value );
+		$this->assertEquals( $mock_text, $return_value );
 		$this->assertEmpty( $echoed );
 
 		ob_start();
@@ -36,7 +36,7 @@ class Test_Helpers extends \WP_UnitTestCase {
 		$actual_user_login = ob_get_clean();
 
 		// Because block_field() has a second argument of true, this should echo the user login and return it.
-		$this->assertEquals( $mock_login, $actual_user_login );
+		$this->assertEquals( $mock_text, $actual_user_login );
 		$this->assertEquals( $return_value, $actual_user_login );
 	}
 }


### PR DESCRIPTION
Update: This description is mainly outdated. Please see the comments below.
* This PR is the beginning of the conversation. The copy can change 😄 
* Right now, this says that maybe the pro license expired.
* But there should probably be a check that this is a pro
field.
<img width="1018" alt="new-notice" src="https://user-images.githubusercontent.com/4063887/57976342-28a45800-79a3-11e9-9c56-0ac4095590b7.png">

Right now, the link goes to:
<img width="1335" alt="link-goes-to" src="https://user-images.githubusercontent.com/4063887/57976353-4d98cb00-79a3-11e9-98fb-42d3476bdf3c.png">

Fixes #242