### PR TITLE
Ensure that the $value is a string before passing it to array_key_exists()

### DIFF
--- a/php/blocks/controls/class-textarea.php
+++ b/php/blocks/controls/class-textarea.php
@@ -140,7 +140,7 @@ class Textarea extends Control_Abstract {
 	 * @return string|null The sanitized rest_base of the post type, or null.
 	 */
 	public function sanitize_new_line_format( $value ) {
-		if ( array_key_exists( $value, $this->get_new_line_formats() ) ) {
+		if ( is_string( $value ) && array_key_exists( $value, $this->get_new_line_formats() ) ) {
 			return $value;
 		}
 		return null;

--- a/tests/php/blocks/controls/test-class-textarea.php
+++ b/tests/php/blocks/controls/test-class-textarea.php
@@ -113,5 +113,8 @@ class Test_Textarea extends \WP_UnitTestCase {
 		$this->assertEquals( 'autop', $this->instance->sanitize_new_line_format( 'autop' ) );
 		$this->assertEquals( 'autobr', $this->instance->sanitize_new_line_format( 'autobr' ) );
 		$this->assertEquals( 'none', $this->instance->sanitize_new_line_format( 'none' ) );
+
+		// If a non-string value is passed, this should return null.
+		$this->assertEquals( null, $this->instance->sanitize_new_line_format( false ) );
 	}
 }


### PR DESCRIPTION
Steps to reproduce:

1. `git checkout develop && git checkout 75fefc3  # checkout the last version, 1.3.0`

2. Create a block with a Textarea field. It probably doesn't matter if you populate any of the inputs, like 'Placeholder Text.' Click 'Publish':

<img width="1431" alt="textarea-here" src="https://user-images.githubusercontent.com/4063887/58068502-2daa0880-7b57-11e9-8b32-84508b585583.png">

3. `git checkout 304e3834f2aedbfb8b7276567ce31d82dd3f520f # Checkout the latest from develop`

4. Go back to the UI from step 2 and click 'Update.' You probably don't have to change anything, just click 'Update.'

5. Expected: The Textarea field appears

6. Actual: There's a PHP warning:

```
Warning: array_key_exists(): The first argument should be either a string or an integer in /srv/www/env/public_html/wp-content/plugins/block-lab/php/blocks/controls/class-textarea.php on line 143
```
<img width="1394" alt="textarea-warning" src="https://user-images.githubusercontent.com/4063887/58068695-f556fa00-7b57-11e9-9c25-5f7d0c7422ce.png">

