### PR TITLE
Correct the wording for license details

### DIFF
--- a/php/views/license.php
+++ b/php/views/license.php
@@ -59,7 +59,7 @@
 							'<p>%1$s %2$s</p>',
 							sprintf(
 								// translators: A date.
-								__( 'Your license will be automatically renewed on %1$s.', 'block-lab' ),
+								__( 'Your license expires on %1$s.', 'block-lab' ),
 								'<strong>' . $expiry . '</strong>'
 							),
 							sprintf(


### PR DESCRIPTION
Closes #308.

Currently licenses do not auto-renew.

In fact, there's no way to tell whether or not the license _will_ auto-renew. See the [EDD Software Licensing API](https://docs.easydigitaldownloads.com/article/384-software-licensing-api).

So I simply changed the copy to "Will expire" instead of "Will auto-renew".