### PR TITLE
Fix a console warning about unique props

### DIFF
--- a/js/blocks/loader/advanced.js
+++ b/js/blocks/loader/advanced.js
@@ -15,7 +15,7 @@ const inspectorControls = ( props, block ) => {
 	);
 
 	return (
-		<InspectorAdvancedControls>
+		<InspectorAdvancedControls key={"inspector-advanced-controls-" + block.name}>
 			<DotTip tipId="block-lab/additional-css-class">
 				<p className="bl-dot-tip" dangerouslySetInnerHTML={{__html: tip}}></p>
 				<p className="bl-dot-tip read-more">

--- a/js/blocks/loader/inspector.js
+++ b/js/blocks/loader/inspector.js
@@ -18,7 +18,7 @@ const inspectorControls = ( props, block ) => {
 		const control = typeof controlFunction !== 'undefined' ? controlFunction( props, field, block ) : null;
 
 		return (
-			<PanelBody>
+			<PanelBody key={"inspector-controls-panel-" + field}>
 				{control}
 			</PanelBody>
 		)


### PR DESCRIPTION

Steps to reproduce
1. Create a new post
2. Add a Block Lab block. I've seen this with many blocks, it might not matter what control(s) the block has, or whether it uses the editor or the Inspector Controls.
3. Expected: There should be minimal console warnings
4. Actual: there's a console warning:
<img width="938" alt="console-warning" src="https://user-images.githubusercontent.com/4063887/59322633-aefb4380-8c9c-11e9-9bd3-723fd8602621.png">

```
react.6025b791.js:276 Warning: Each child in a list should have a unique "key" prop.

Check the render method of `edit`. See https://fb.me/react-warning-keys for more information.
    in ForwardRef(PanelBody) (created by edit)
    in edit (created by Edit)
    in Edit (created by WithToolbarControls(Edit))
    in WithToolbarControls(Edit) (created by WithInspectorControl(WithToolbarControls(Edit)))
    in WithInspectorControl(WithToolbarControls(Edit)) (created by WithInspectorControl(WithInspectorControl(WithToolbarControls(Edit))))
    in WithInspectorControl(WithInspectorControl(WithToolbarControls(Edit)))
    in Unknown (created by WithDispatch(Component))
    in WithDispatch(Component)
    in Unknown (created by WithMultipleValidation(WithInspectorControl(WithInspectorControl(WithToolbarControls(Edit)))))
    in WithMultipleValidation(WithInspectorControl(WithInspectorControl(WithToolbarControls(Edit)))) (created by WithFilters(Edit))
    in WithFilters(Edit) (created by BlockEdit)
    in BlockEdit (created by HoverArea)
    in BlockCrashBoundary (created by HoverArea)
    in div (created by IgnoreNestedEvents)
    in IgnoreNestedEvents (created by ForwardRef(IgnoreNestedEvents))
    in ForwardRef(IgnoreNestedEvents) (created by HoverArea)
    in div (created by HoverArea)
    in div (created by IgnoreNestedEvents)
    in IgnoreNestedEvents (created by ForwardRef(IgnoreNestedEvents))
    in ForwardRef(IgnoreNestedEvents) (created by HoverArea)
    in HoverArea
    in Unknown (created by WithSelect(HoverArea))
    in WithSelect(HoverArea) (created by BlockListBlock)
    in BlockListBlock
    in Unknown
    in Unknown (created by (BlockListBlock))
    in (BlockListBlock) (created by WithFilters(BlockListBlock))
    in WithFilters(BlockListBlock) (created by WithDispatch(WithFilters(BlockListBlock)))
    in WithDispatch(WithFilters(BlockListBlock))
    in Unknown (created by WithSelect(WithDispatch(WithFilters(BlockListBlock))))
    in WithSelect(WithDispatch(WithFilters(BlockListBlock)))
    in Unknown (created by Pure(WithViewportMatch(WithSelect(WithDispatch(WithFilters(BlockListBlock))))))
    in Pure(WithViewportMatch(WithSelect(WithDispatch(WithFilters(BlockListBlock))))) (created by BlockList)
    in div (created by BlockList)
    in BlockList (created by WithDispatch(BlockList))
    in WithDispatch(BlockList)
    in Unknown (created by WithSelect(WithDispatch(BlockList)))
    in WithSelect(WithDispatch(BlockList))
    in Unknown (created by VisualEditor)
    in div (created by CopyHandler)
    in CopyHandler (created by WithDispatch(CopyHandler))
    in WithDispatch(CopyHandler) (created by VisualEditor)
    in div (created by ObserveTyping)
    in ObserveTyping (created by WithSafeTimeout(ObserveTyping))
    in WithSafeTimeout(ObserveTyping) (created by WithDispatch(WithSafeTimeout(ObserveTyping)))
    in WithDispatch(WithSafeTimeout(ObserveTyping))
    in Unknown (created by WithSelect(WithDispatch(WithSafeTimeout(ObserveTyping))))
    in WithSelect(WithDispatch(WithSafeTimeout(ObserveTyping))) (created by VisualEditor)
    in div (created by WritingFlow)
    in div (created by WritingFlow)
    in WritingFlow (created by WithDispatch(WritingFlow))
    in WithDispatch(WritingFlow)
    in Unknown (created by WithSelect(WithDispatch(WritingFlow)))
    in WithSelect(WithDispatch(WritingFlow)) (created by VisualEditor)
    in div (created by BlockSelectionClearer)
    in BlockSelectionClearer (created by WithDispatch(BlockSelectionClearer))
    in WithDispatch(BlockSelectionClearer)
    in Unknown (created by WithSelect(WithDispatch(BlockSelectionClearer)))
    in WithSelect(WithDispatch(BlockSelectionClearer)) (created by VisualEditor)
    in VisualEditor (created by Layout)
    in div (created by Layout)
    in div (created by FocusReturnProvider)
    in FocusReturnProvider (created by Layout)
    in Layout
    in Unknown (created by WithViewportMatch(Layout))
    in WithViewportMatch(Layout) (created by NavigateRegions(WithViewportMatch(Layout)))
    in div (created by NavigateRegions(WithViewportMatch(Layout)))
    in NavigateRegions(WithViewportMatch(Layout)) (created by WithDispatch(NavigateRegions(WithViewportMatch(Layout))))
    in WithDispatch(NavigateRegions(WithViewportMatch(Layout)))
    in Unknown (created by WithSelect(WithDispatch(NavigateRegions(WithViewportMatch(Layout)))))
    in WithSelect(WithDispatch(NavigateRegions(WithViewportMatch(Layout)))) (created by Editor)
    in ErrorBoundary (created by Editor)
    in div (created by DropZoneProvider)
    in DropZoneProvider (created by BlockEditorProvider)
    in SlotFillProvider (created by BlockEditorProvider)
    in BlockEditorProvider (created by WithDispatch(BlockEditorProvider))
    in WithDispatch(BlockEditorProvider)
    in Unknown (created by Context.Consumer)
    in WithRegistryProvider(WithDispatch(BlockEditorProvider)) (created by EditorProvider)
    in EditorProvider (created by WithDispatch(EditorProvider))
    in WithDispatch(EditorProvider)
    in Unknown (created by WithSelect(WithDispatch(EditorProvider)))
    in WithSelect(WithDispatch(EditorProvider)) (created by Editor)
    in StrictMode (created by Editor)
    in Editor
    in Unknown (created by WithSelect(Editor))
    in WithSelect(Editor)
```

It looks like this is from the Inspector Controls. 

It'd be interesting to see if you see this warning also. But with this PR, I don't see it anymore.