### PR TITLE
🐛Make sure zero can be selected in Range Control due to boolean bug.

### DIFF
--- a/js/blocks/controls/range.js
+++ b/js/blocks/controls/range.js
@@ -9,10 +9,12 @@ const BlockLabRangeControl = ( props, field, block ) => {
 			afterIcon={field.afterIcon}
 			label={field.label}
 			help={field.help}
-			value={attr[ field.name ] || field.default}
+			value={ ( attr[ field.name ] || '0' == attr[ field.name ] ) ? attr[ field.name ] : field.default }
 			onChange={rangeControl => {
-				attr[ field.name ] = rangeControl
-				setAttributes( attr )
+				if ( undefined !== rangeControl ) {
+					attr[ field.name ] = rangeControl
+					setAttributes( attr )
+				}
 			}}
 			min={field.min}
 			max={field.max}

--- a/js/blocks/controls/range.js
+++ b/js/blocks/controls/range.js
@@ -9,12 +9,10 @@ const BlockLabRangeControl = ( props, field, block ) => {
 			afterIcon={field.afterIcon}
 			label={field.label}
 			help={field.help}
-			value={ ( attr[ field.name ] || '0' == attr[ field.name ] ) ? attr[ field.name ] : field.default }
+			value={ ( attr[ field.name ] || '0' == attr[ field.name ] || undefined == attr[ field.name ] ) ? attr[ field.name ] : field.default }
 			onChange={rangeControl => {
-				if ( undefined !== rangeControl ) {
-					attr[ field.name ] = rangeControl
-					setAttributes( attr )
-				}
+				attr[ field.name ] = rangeControl
+				setAttributes( attr )
 			}}
 			min={field.min}
 			max={field.max}


### PR DESCRIPTION
Fixes https://github.com/getblocklab/block-lab/issues/333

Boolean issue causes range control to never be set at zero.