### PR TITLE
Version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Changelog #
 
+### 1.3.2 - 2019-06-21 ###
+
+* New: Rich Text Control (for Block Lab Pro users)!
+* New: Show Block Category in the list table
+* New: We've got a new `block_lab_render_template` hook which fires before rendering a block on the front end. Great for enqueuing JS
+* Tweak: Updated logo
+* Tweak: Prevent block field slugs from changing when you edit the field title
+* Fix: Saving your license key no longer results in an error page
+* Fix: License details screen showing the wrong information
+* Fix: Remove duplicate IDs on the edit block screen
+* Fix: Range sliders can now set a minimum value of zero
+* Fix: A console warning about unique props
+
 ### 1.3.1 - 2019-05-22 ###
 
 * New: Support for Gutenberg's built-in Additional CSS Class in your block template, by using the field `className`. [Read more](https://github.com/getblocklab/block-lab/wiki/7.-FAQ)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Contributors: lukecarbis, ryankienstra, Stino11, rheinardkorf
 Tags: Gutenberg, Blocks
 Requires at least: 5.0
-Tested up to: 5.2.1
+Tested up to: 5.2
 Requires PHP: 5.4
 Stable tag: trunk
 License: GPLv2 or later

--- a/block-lab.php
+++ b/block-lab.php
@@ -9,7 +9,7 @@
  * Plugin Name: Block Lab
  * Plugin URI: https://getblocklab.com
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.3.1
+ * Version: 1.3.2
  * Author: Block Lab
  * Author URI: https://getblocklab.com
  * License: GPL2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "block-lab",
   "title": "Block Lab",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "homepage": "https://getblocklab.com",
   "repository": {
     "type": "git",


### PR DESCRIPTION
It's a biggun!

### 1.3.2 - 2019-06-21 ###

* New: Rich Text Control (for Block Lab Pro users)!
* New: Show Block Category in the list table
* New: We've got a new `block_lab_render_template` hook which fires before rendering a block on the front end. Great for enqueuing JS
* Tweak: Updated logo
* Tweak: Prevent block field slugs from changing when you edit the field title
* Fix: Saving your license key no longer results in an error page
* Fix: License details screen showing the wrong information
* Fix: Remove duplicate IDs on the edit block screen
* Fix: Range sliders can now set a minimum value of zero
* Fix: A console warning about unique props
