### PR TITLE
Fix an issue where the block_field( 'className' ) doesn't output anything

### DIFF
--- a/php/helpers.php
+++ b/php/helpers.php
@@ -28,7 +28,7 @@ function block_field( $name, $echo = true ) {
 	if (
 		! isset( $block_lab_attributes ) ||
 		! is_array( $block_lab_attributes ) ||
-		! isset( $block_lab_config->fields[ $name ] )
+		( ! isset( $block_lab_config->fields[ $name ] ) && 'className' !== $name )
 	) {
 		return null;
 	}
@@ -44,46 +44,48 @@ function block_field( $name, $echo = true ) {
 	}
 
 	// Cast block value as correct type.
-	switch ( $block_lab_config->fields[ $name ]->type ) {
-		case 'string':
-			$value = strval( $value );
-			break;
-		case 'textarea':
-			$value = strval( $value );
-			if ( isset( $block_lab_config->fields[ $name ]->settings['new_lines'] ) ) {
-				if ( 'autop' === $block_lab_config->fields[ $name ]->settings['new_lines'] ) {
-					$value = wpautop( $value );
+	if ( isset( $block_lab_config->fields[ $name ]->type ) ) {
+		switch ( $block_lab_config->fields[ $name ]->type ) {
+			case 'string':
+				$value = strval( $value );
+				break;
+			case 'textarea':
+				$value = strval( $value );
+				if ( isset( $block_lab_config->fields[ $name ]->settings['new_lines'] ) ) {
+					if ( 'autop' === $block_lab_config->fields[ $name ]->settings['new_lines'] ) {
+						$value = wpautop( $value );
+					}
+					if ( 'autobr' === $block_lab_config->fields[ $name ]->settings['new_lines'] ) {
+						$value = nl2br( $value );
+					}
 				}
-				if ( 'autobr' === $block_lab_config->fields[ $name ]->settings['new_lines'] ) {
-					$value = nl2br( $value );
+				break;
+			case 'boolean':
+				if ( 1 === $value ) {
+					$value = true;
 				}
-			}
-			break;
-		case 'boolean':
-			if ( 1 === $value ) {
-				$value = true;
-			}
-			break;
-		case 'integer':
-			$value = intval( $value );
-			break;
-		case 'array':
-			if ( ! $value ) {
-				$value = array();
-			} else {
-				$value = (array) $value;
-			}
-			break;
+				break;
+			case 'integer':
+				$value = intval( $value );
+				break;
+			case 'array':
+				if ( ! $value ) {
+					$value = array();
+				} else {
+					$value = (array) $value;
+				}
+				break;
+		}
 	}
 
-	$control = $block_lab_config->fields[ $name ]->control;
+	$control = isset( $block_lab_config->fields[ $name ]->control ) ? $block_lab_config->fields[ $name ]->control : null;
 
 	/**
 	 * Filters the value to be made available or echoed on the front-end template.
 	 *
-	 * @param mixed  $value The value.
-	 * @param string $control The type of the control, like 'user'.
-	 * @param bool   $echo Whether or not this value will be echoed.
+	 * @param mixed       $value The value.
+	 * @param string|null $control The type of the control, like 'user', or null if this is the 'className', which has no control.
+	 * @param bool        $echo Whether or not this value will be echoed.
 	 */
 	$value = apply_filters( 'block_lab_field_value', $value, $control, $echo );
 

--- a/tests/php/test-helpers.php
+++ b/tests/php/test-helpers.php
@@ -21,8 +21,11 @@ class Test_Helpers extends \WP_UnitTestCase {
 		global $block_lab_attributes, $block_lab_config;
 
 		$field_name                          = 'test-user';
+		$class_key                           = 'className';
+		$expected_class                      = 'baz-class';
 		$mock_text                           = 'Example text';
 		$block_lab_attributes[ $field_name ] = $mock_text;
+		$block_lab_attributes[ $class_key ]  = $expected_class;
 
 		$field_config = array( 'control' => 'text' );
 		$block_config = array(
@@ -41,6 +44,13 @@ class Test_Helpers extends \WP_UnitTestCase {
 		$this->assertEquals( $mock_text, $return_value );
 		$this->assertEmpty( $echoed );
 
+		// Test the same scenario as above, but for 'className'.
+		ob_start();
+		$return_value = block_field( $class_key, false );
+		$echoed       = ob_get_clean();
+		$this->assertEquals( $expected_class, $return_value );
+		$this->assertEmpty( $echoed );
+
 		ob_start();
 		$return_value      = block_field( $field_name, true );
 		$actual_user_login = ob_get_clean();
@@ -48,5 +58,13 @@ class Test_Helpers extends \WP_UnitTestCase {
 		// Because block_field() has a second argument of true, this should echo the user login and return it.
 		$this->assertEquals( $mock_text, $actual_user_login );
 		$this->assertEquals( $return_value, $actual_user_login );
+
+		ob_start();
+		$return_value      = block_field( $class_key, true );
+		$actual_class = ob_get_clean();
+
+		// Test the same scenario as above, but for 'className'.
+		$this->assertEquals( $expected_class, $actual_class );
+		$this->assertEquals( $return_value, $actual_class );
 	}
 }


### PR DESCRIPTION
@RobStino found this issue, where `block_field( 'className' )` has no output. Similarly, `block_value( 'className' )` didn't return anything.

