### PR TITLE
Version 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog #
 
+### 1.3.3 - 2019-06-21 ###
+
+* Fix: The previous release broke the `className` field, used for the Additional CSS Class setting. This fixes it.
+
 ### 1.3.2 - 2019-06-21 ###
 
 * New: Rich Text Control (for Block Lab Pro users)!

--- a/block-lab.php
+++ b/block-lab.php
@@ -9,7 +9,7 @@
  * Plugin Name: Block Lab
  * Plugin URI: https://getblocklab.com
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.3.2
+ * Version: 1.3.3
  * Author: Block Lab
  * Author URI: https://getblocklab.com
  * License: GPL2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "block-lab",
   "title": "Block Lab",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "homepage": "https://getblocklab.com",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The previous release broke the `className` field, used for the Additional CSS Class setting. This fixes it.