### PR TITLE
Load child theme templates before parent theme

### DIFF
--- a/php/helpers.php
+++ b/php/helpers.php
@@ -195,15 +195,15 @@ function block_lab_locate_template( $template_names, $path = '', $single = true 
 			}
 		}
 
-		if ( file_exists( trailingslashit( $stylesheet_path ) . $template_name ) ) {
-			$located[] = trailingslashit( $stylesheet_path ) . $template_name;
+		if ( file_exists( trailingslashit( $template_path ) . $template_name ) ) {
+			$located[] = trailingslashit( $template_path ) . $template_name;
 			if ( $single ) {
 				break;
 			}
 		}
 
-		if ( file_exists( trailingslashit( $template_path ) . $template_name ) ) {
-			$located[] = trailingslashit( $template_path ) . $template_name;
+		if ( file_exists( trailingslashit( $stylesheet_path ) . $template_name ) ) {
+			$located[] = trailingslashit( $stylesheet_path ) . $template_name;
 			if ( $single ) {
 				break;
 			}


### PR DESCRIPTION
Closes #334.

Tested with both child theme and parent theme template files and stylesheets.

![Screen Shot 2019-07-22 at 7 20 20 pm](https://user-images.githubusercontent.com/1097667/61621288-00441d00-acb6-11e9-8030-21a580ff3a78.png)
![Screen Shot 2019-07-22 at 7 20 10 pm](https://user-images.githubusercontent.com/1097667/61621291-01754a00-acb6-11e9-9846-cf17be2553e9.png)

My parent template looks like this:
```
<h3 class="css-bugfix">parent</h3>
```

My child template looks like this:
```
<h3 class="css-bugfix">child</h3>
```

My parent stylesheet looks like this:
```
h3.css-bugfix {
	color: hotpink;
}
```

My child stylesheet looks like this:
```
h3.css-bugfix {
	color: yellow;
}
```

When I view the block (tested in both the editor and frontend), I see the child template / stylesheet, as expected:
![Screen Shot 2019-07-22 at 7 21 16 pm](https://user-images.githubusercontent.com/1097667/61621402-400b0480-acb6-11e9-9e55-7337113b6ee7.png)

In `develop` I (incorrectly) see the parent template / stylesheet:
![Screen Shot 2019-07-22 at 7 21 38 pm](https://user-images.githubusercontent.com/1097667/61621450-4ef1b700-acb6-11e9-9ab8-4d831961af67.png)

