### PR TITLE
Global styles

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -107,8 +107,8 @@ install_test_suite() {
 	if [ ! -d $WP_TESTS_DIR ]; then
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+		svn co https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
 
 	if [ ! -f wp-tests-config.php ]; then

--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -105,6 +105,8 @@ class Loader extends Component_Abstract {
 			$this->enqueue_block_styles( $block_name, array( 'preview', 'block' ) );
 		}
 
+		$this->enqueue_global_styles();
+
 		// Used to conditionally show notices for blocks belonging to an author.
 		$author_blocks = get_posts(
 			array(
@@ -277,6 +279,12 @@ class Loader extends Component_Abstract {
 			}
 
 			$this->enqueue_block_styles( $block->name, 'block' );
+
+			/**
+			 * The wp_enqueue_style function handles duplicates, so we don't need to worry about multiple blocks
+			 * loading the global styles more than once.
+			 */
+			$this->enqueue_global_styles();
 		}
 
 		$block_lab_attributes = $attributes;
@@ -345,6 +353,30 @@ class Loader extends Component_Abstract {
 		if ( ! empty( $stylesheet_url ) ) {
 			wp_enqueue_style(
 				"block-lab__block-{$name}",
+				$stylesheet_url,
+				array(),
+				wp_get_theme()->get( 'Version' )
+			);
+		}
+	}
+	/**
+	 * Enqueues global block styles.
+	 */
+	public function enqueue_global_styles() {
+		$locations = array(
+			'blocks/css/blocks.css',
+			'blocks/blocks.css',
+		);
+
+		$stylesheet_path = block_lab_locate_template( $locations );
+		$stylesheet_url  = str_replace( untrailingslashit( ABSPATH ), '', $stylesheet_path );
+
+		/**
+		 * Enqueue the stylesheet, if it exists.
+		 */
+		if ( ! empty( $stylesheet_url ) ) {
+			wp_enqueue_style(
+				'block-lab__global-styles',
 				$stylesheet_url,
 				array(),
 				wp_get_theme()->get( 'Version' )

--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -359,6 +359,7 @@ class Loader extends Component_Abstract {
 			);
 		}
 	}
+
 	/**
 	 * Enqueues global block styles.
 	 */

--- a/tests/php/blocks/test-class-loader.php
+++ b/tests/php/blocks/test-class-loader.php
@@ -47,34 +47,39 @@ class Test_Loader extends \WP_UnitTestCase {
 		$block->from_array( array( 'name' => $block_name ) );
 
 		// Test that the do_action() call with this action runs, and that it allows enqueuing a script.
-		add_action( 'block_lab_render_template', function( $block ) use ( $block_name, $slug, $script_url) {
-			if ( $block_name === $block->name ) {
-				wp_enqueue_script( $slug, $script_url, array(), '0.1', true );
+		add_action(
+			'block_lab_render_template',
+			function( $block ) use ( $block_name, $slug, $script_url ) {
+				if ( $block_name === $block->name ) {
+					wp_enqueue_script( $slug, $script_url, array(), '0.1', true );
+				}
 			}
-		} );
+		);
 
 		$this->instance->render_block_template( $block, array() );
 		$scripts = wp_scripts();
 		$script  = $scripts->registered[ $slug ];
 
-		$this->assertTrue( in_array( $slug, $scripts->queue ) );
+		$this->assertTrue( in_array( $slug, $scripts->queue, true ) );
 		$this->assertEquals( $slug, $script->handle );
 		$this->assertEquals( $script_url, $script->src );
-
 
 		// Test that the do_action() call with the dynamic name runs, like 'block_lab_render_template_bl-dynamic-testing-slug'.
 		$slug       = 'bl-dynamic-testing-slug';
 		$script_url = 'https://example.com/another-script.js';
 
-		add_action( "block_lab_render_template_{$block_name}", function( $block ) use ( $block_name, $slug, $script_url) {
-			wp_enqueue_script( $slug, $script_url, array(), '0.1', true );
-		} );
+		add_action(
+			"block_lab_render_template_{$block_name}",
+			function( $block ) use ( $block_name, $slug, $script_url ) {
+				wp_enqueue_script( $slug, $script_url, array(), '0.1', true );
+			}
+		);
 
 		$this->instance->render_block_template( $block, array() );
 		$scripts = wp_scripts();
 		$script  = $scripts->registered[ $slug ];
 
-		$this->assertTrue( in_array( $slug, $scripts->queue ) );
+		$this->assertTrue( in_array( $slug, $scripts->queue, true ) );
 		$this->assertEquals( $slug, $script->handle );
 		$this->assertEquals( $script_url, $script->src );
 	}
@@ -130,5 +135,49 @@ class Test_Loader extends \WP_UnitTestCase {
 		$this->instance->enqueue_block_styles( 'does-not-exist', 'block' );
 		$this->assertNotContains( $block_handle, $wp_styles->queue );
 		$this->assertArrayNotHasKey( $block_handle, $wp_styles->registered );
+	}
+
+	/**
+	 * Test enqueue_global_styles.
+	 *
+	 * @covers \Block_Lab\Blocks\Loader::enqueue_global_styles()
+	 */
+	public function test_enqueue_global_styles() {
+		$wp_styles       = wp_styles();
+		$enqueue_handle  = 'block-lab__global-styles';
+		$stylesheet_path = get_template_directory();
+
+		if ( ! file_exists( $stylesheet_path . '/blocks/' ) ) {
+			mkdir( $stylesheet_path . '/blocks/' );
+			mkdir( $stylesheet_path . '/blocks/css/' );
+		}
+
+		// In order of reverse priority.
+		$files = array(
+			"{$stylesheet_path}/blocks/blocks.css",
+			"{$stylesheet_path}/blocks/css/blocks.css",
+		);
+
+		// Remove previous template files so that we can correctly check load order.
+		foreach ( $files as $file ) {
+			if ( file_exists( $file ) ) {
+				unlink( $file );
+			}
+		}
+
+		// Check that the correct stylesheet is enqueued.
+		foreach ( $files as $key => $file ) {
+			file_put_contents( $file, '' ); // @codingStandardsIgnoreLine
+			$file_url = str_replace( untrailingslashit( ABSPATH ), '', $file );
+
+			$this->instance->enqueue_global_styles();
+
+			$this->assertContains( $enqueue_handle, $wp_styles->queue );
+			$this->assertArrayHasKey( $enqueue_handle, $wp_styles->registered );
+			$this->assertSame( $wp_styles->registered[ $enqueue_handle ]->src, $file_url, "Trying to enqueue file #{$key} ({$file_url})." );
+
+			wp_deregister_style( $enqueue_handle );
+			wp_dequeue_style( $enqueue_handle );
+		}
 	}
 }

--- a/tests/php/blocks/test-class-loader.php
+++ b/tests/php/blocks/test-class-loader.php
@@ -158,13 +158,6 @@ class Test_Loader extends \WP_UnitTestCase {
 			"{$stylesheet_path}/blocks/css/blocks.css",
 		);
 
-		// Remove previous template files so that we can correctly check load order.
-		foreach ( $files as $file ) {
-			if ( file_exists( $file ) ) {
-				unlink( $file );
-			}
-		}
-
 		// Check that the correct stylesheet is enqueued.
 		foreach ( $files as $key => $file ) {
 			file_put_contents( $file, '' ); // @codingStandardsIgnoreLine
@@ -178,6 +171,7 @@ class Test_Loader extends \WP_UnitTestCase {
 
 			wp_deregister_style( $enqueue_handle );
 			wp_dequeue_style( $enqueue_handle );
+			unlink( $file );
 		}
 	}
 }


### PR DESCRIPTION
With this PR, Block Lab will try to enqueue a global stylesheet.

It will try to do this under one of two conditions:
1. You are using Gutenberg
2. _Any_ custom block lab block is used on the page

*Note*: These styles won't load if you're not using any Block Lab blocks.

The global stylesheet will be loaded if it exists in one of these places:
- `{theme}/blocks/blocks.css`
- `{theme}/blocks/css/blocks.css`
- `{child theme}/blocks/blocks.css`
- `{child theme}/blocks/css/blocks.css`

If the global stylesheet exists in multiple places, it will only be loaded the first time it's found. So if you've got one in `blocks/blocks.css` _and_ `blocks/css/blocks.css`, then second stylesheet will be ignored.

Note that once #370 is merged, the child theme will be preferenced over the parent theme.

Closes #351 .