### PR TITLE
Block theme folder structure

### DIFF
--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -329,6 +329,7 @@ class Loader extends Component_Abstract {
 			$locations = array_merge(
 				$locations,
 				array(
+					"blocks/{$name}/{$type}.css",
 					"blocks/css/{$type}-{$name}.css",
 					"blocks/{$type}-{$name}.css",
 				)
@@ -378,10 +379,10 @@ class Loader extends Component_Abstract {
 			}
 
 			$template_file = "blocks/{$type}-{$name}.php";
-			$generic_file  = "blocks/{$type}.php";
 			$templates     = [
-				$generic_file,
+				"blocks/{$name}/{$type}.php",
 				$template_file,
+				"blocks/{$type}.php",
 			];
 
 			$located = block_lab_locate_template( $templates );

--- a/tests/php/blocks/test-class-loader.php
+++ b/tests/php/blocks/test-class-loader.php
@@ -93,15 +93,22 @@ class Test_Loader extends \WP_UnitTestCase {
 
 		if ( ! file_exists( $stylesheet_path . '/blocks/' ) ) {
 			mkdir( $stylesheet_path . '/blocks/' );
+		}
+		if ( ! file_exists( $stylesheet_path . '/blocks/css/' ) ) {
 			mkdir( $stylesheet_path . '/blocks/css/' );
+		}
+		if ( ! file_exists( $stylesheet_path . "/blocks/{$block_name}/" ) ) {
+			mkdir( $stylesheet_path . "/blocks/{$block_name}/" );
 		}
 
 		// In order of reverse priority.
 		$files = array(
 			"{$stylesheet_path}/blocks/block-{$block_name}.css",
 			"{$stylesheet_path}/blocks/css/block-{$block_name}.css",
+			"{$stylesheet_path}/blocks/{$block_name}/block.css",
 			"{$stylesheet_path}/blocks/preview-{$block_name}.css",
 			"{$stylesheet_path}/blocks/css/preview-{$block_name}.css",
+			"{$stylesheet_path}/blocks/{$block_name}/preview.css",
 		);
 
 		// Remove previous template files so that we can correctly check load order.


### PR DESCRIPTION
This PR adds support for structuring blocks inside directories like so:

- /theme
    - /blocks
        - /block_one
            - preview.php
            - block.php
            - block.css
        - /block_two
            - preview.php
            - block.php
            - block.css

Note that it does _not_ auto-enqueue javascript files, as suggested in the original issue (we should open a separate issue for that, if one doesn't already exist).

Block templates are expected to load in the following order:

1. `blocks/{name}/preview.php` (if in the editor)
2. `blocks/preview-{name}.php` (if in the editor)
3. `blocks/preview.php` (if in the editor)
4. `blocks/{name}/block.php`
5. `blocks/block-{name}.php`
6. `blocks/block.php`

Block styles are expected to load in the following order:

1. `blocks/{name}/preview.css` (if in the editor)
2. `blocks/css/preview-{name}.css` (if in the editor)
3. `blocks/preview-{name}.css` (if in the editor)
4. `blocks/{name}/block.css`
5. `blocks/css/block-{name}.css`
6. `blocks/preview-{name}.css`

Closes #301.