### PR TITLE
Add padding to right side of upgrade page

### DIFF
--- a/css/admin.upgrade.css
+++ b/css/admin.upgrade.css
@@ -1,5 +1,5 @@
 .block-lab-pro {
-	padding-top: 20px;
+	padding: 20px 20px 0 0;
 	margin: 0 auto;
 	max-width: 1280px;
 }


### PR DESCRIPTION
The upgrade page is missing padding on the right hand side. This PR fixes that with a one-line CSS change.

Before:
![Screen Shot 2019-07-28 at 2 47 28 pm](https://user-images.githubusercontent.com/1097667/62002408-ad9bb280-b146-11e9-93c9-e731d935ac70.png)

After:
![Screen Shot 2019-07-28 at 2 46 52 pm](https://user-images.githubusercontent.com/1097667/62002410-b096a300-b146-11e9-9352-6cd0302bc757.png)
