### PR TITLE
For the textarea control, use a textarea for the default setting

### DIFF
--- a/php/blocks/controls/class-textarea.php
+++ b/php/blocks/controls/class-textarea.php
@@ -44,10 +44,20 @@ class Textarea extends Control_Abstract {
 	 * @return void
 	 */
 	public function register_settings() {
-		foreach ( array( 'location', 'help', 'default', 'placeholder' ) as $setting ) {
+		foreach ( array( 'location', 'help' ) as $setting ) {
 			$this->settings[] = new Control_Setting( $this->settings_config[ $setting ] );
 		}
 
+		$this->settings[] = new Control_Setting(
+			array(
+				'name'     => 'default',
+				'label'    => __( 'Default Value', 'block-lab' ),
+				'type'     => 'textarea',
+				'default'  => '',
+				'sanitize' => 'sanitize_textarea_field',
+			)
+		);
+		$this->settings[] = new Control_Setting( $this->settings_config['placeholder'] );
 		$this->settings[] = new Control_Setting(
 			array(
 				'name'     => 'maxlength',

--- a/tests/php/blocks/controls/test-class-textarea.php
+++ b/tests/php/blocks/controls/test-class-textarea.php
@@ -81,10 +81,10 @@ class Test_Textarea extends \WP_UnitTestCase {
 			array(
 				'name'     => 'default',
 				'label'    => 'Default Value',
-				'type'     => 'text',
+				'type'     => 'textarea',
 				'default'  => '',
 				'help'     => '',
-				'sanitize' => 'sanitize_text_field',
+				'sanitize' => 'sanitize_textarea_field',
 				'validate' => '',
 				'value'    => null,
 			),


### PR DESCRIPTION
* Before, the `Textarea` control had an `<input>` for the 'Default Value' setting
* Now, it has a `<textarea>` for the default value
* This is in response to a WordPress.org [support topic](https://wordpress.org/support/topic/default-value-for-textarea-not-accepting-multiple-lines/#post-11802107)
* It looks to be backwards-compatible with the previous default value saved in the `<input>`, but more testing would be appreciated

# Edit Block UI

<img width="964" alt="textarea-default-value" src="https://user-images.githubusercontent.com/4063887/62486129-093bf080-b784-11e9-82c3-ef721dd1f55f.png">

# Block Editor UI

<img width="806" alt="ta-field" src="https://user-images.githubusercontent.com/4063887/62486225-4d2ef580-b784-11e9-8255-6cf2631b8135.png">

Maybe it'd make sense to also make the 'placeholder' setting a `<textarea>`. But I'm not sure how many people need a multiple-line placeholder.



