### PR TITLE
Remember default value of form field in the Block Builder

### DIFF
--- a/js/admin.block-post.js
+++ b/js/admin.block-post.js
@@ -22,7 +22,7 @@
 				edit     = field.find( '.block-fields-actions-edit' ),
 				label    = field.find( '.block-fields-edit-label input' );
 
-				$( '.block-fields-rows' ).append( field );
+			$( '.block-fields-rows' ).append( field );
 			$( '.block-no-fields' ).hide();
 
 			edit.trigger( 'click' );

--- a/js/admin.block-post.js
+++ b/js/admin.block-post.js
@@ -18,11 +18,16 @@
 		$( '#block-add-field' ).on( 'click', function() {
 			let template = wp.template( 'field-repeater' ),
 				data     = { uid: new Date().getTime() },
-				field    = $( template( data ) );
-			$( '.block-fields-rows' ).append( field );
+				field    = $( template( data ) ),
+				edit     = field.find( '.block-fields-actions-edit' ),
+				label    = field.find( '.block-fields-edit-label input' );
+
+				$( '.block-fields-rows' ).append( field );
 			$( '.block-no-fields' ).hide();
-			field.find( '.block-fields-actions-edit' ).trigger( 'click' );
-			field.find( '.block-fields-edit-label input' ).select();
+
+			edit.trigger( 'click' );
+			label.data( 'defaultValue', label.val() );
+			label.select();
 		});
 
 		$( '#block_properties .block-properties-icon-select span' ).on( 'click', function() {
@@ -143,6 +148,10 @@
 				}
 			})
 			.on( 'blur', '.block-fields-edit-label input', function() {
+				// If the value hasn't changed from default, don't turn off autoslug.
+				if ( $( this ).data( 'defaultValue' ) === $( this ).val() ) {
+					return;
+				}
 				$( this )
 					.closest( '.block-fields-edit' )
 					.find( '.block-fields-edit-name input' )


### PR DESCRIPTION
This is so that we can keep autoslugging on if the default value hasn't changed.

**Before**

![Before](https://user-images.githubusercontent.com/1097667/63062393-11dab680-bf3c-11e9-9c2c-0e6c9ce914fd.gif)

**After**

![After](https://user-images.githubusercontent.com/1097667/63062415-2fa81b80-bf3c-11e9-9197-1d50c5c464e7.gif)


Closes #378.