### PR TITLE
Copy the set_util() method into init(), add helper method for post type

### DIFF
--- a/php/admin/class-import.php
+++ b/php/admin/class-import.php
@@ -225,7 +225,7 @@ class Import extends Component_Abstract {
 					'post_name'    => $config['name'],
 					'post_content' => wp_slash( $json ),
 					'post_status'  => 'publish',
-					'post_type'    => block_lab()->block_post->slug,
+					'post_type'    => block_lab()->get_post_type_slug(),
 				)
 			);
 

--- a/php/admin/class-onboarding.php
+++ b/php/admin/class-onboarding.php
@@ -50,7 +50,7 @@ class Onboarding extends Component_Abstract {
 		}
 
 		$screen = get_current_screen();
-		$slug   = $this->plugin->block_post->slug;
+		$slug   = block_lab()->get_post_type_slug();
 
 		if ( ! is_object( $screen ) ) {
 			return;

--- a/php/admin/class-onboarding.php
+++ b/php/admin/class-onboarding.php
@@ -302,7 +302,7 @@ class Onboarding extends Component_Abstract {
 		 */
 		$blocks = get_posts(
 			array(
-				'post_type'   => block_lab()->block_post->slug,
+				'post_type'   => block_lab()->get_post_type_slug(),
 				'numberposts' => '1',
 				'post_status' => 'any',
 				'fields'      => 'ids',
@@ -320,7 +320,7 @@ class Onboarding extends Component_Abstract {
 				'post_title'   => __( 'Example Block', 'block-lab' ),
 				'post_name'    => 'example-block',
 				'post_status'  => 'draft',
-				'post_type'    => block_lab()->block_post->slug,
+				'post_type'    => block_lab()->get_post_type_slug(),
 				'post_content' => wp_json_encode(
 					array(
 						'block-lab\/example-block' => array(

--- a/php/admin/class-settings.php
+++ b/php/admin/class-settings.php
@@ -57,7 +57,7 @@ class Settings extends Component_Abstract {
 	 */
 	public function add_submenu_pages() {
 		add_submenu_page(
-			'edit.php?post_type=' . block_lab()->block_post->slug,
+			'edit.php?post_type=' . block_lab()->get_post_type_slug(),
 			__( 'Block Lab Settings', 'block-lab' ),
 			__( 'Settings', 'block-lab' ),
 			'manage_options',

--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -471,7 +471,7 @@ class Loader extends Component_Abstract {
 
 		$block_posts = new \WP_Query(
 			[
-				'post_type'      => block_lab()->block_post->slug,
+				'post_type'      => block_lab()->get_post_type_slug(),
 				'post_status'    => 'publish',
 				'posts_per_page' => - 1,
 			]

--- a/php/class-plugin-abstract.php
+++ b/php/class-plugin-abstract.php
@@ -54,6 +54,14 @@ abstract class Plugin_Abstract implements Plugin_Interface {
 	protected $slug;
 
 	/**
+	 * The slug of the post type that stores the blocks.
+	 *
+	 * @since 1.3.5
+	 * @var string
+	 */
+	protected $post_type_slug = 'block_lab';
+
+	/**
 	 * URL to the main plugin directory.
 	 *
 	 * @since 1.0.0
@@ -68,13 +76,6 @@ abstract class Plugin_Abstract implements Plugin_Interface {
 	 * @var string
 	 */
 	protected $version;
-
-	/**
-	 * Utility methods.
-	 *
-	 * @var Util
-	 */
-	protected $util;
 
 	/**
 	 * Allows calling methods in the Util class, directly in this class.
@@ -183,6 +184,15 @@ abstract class Plugin_Abstract implements Plugin_Interface {
 	}
 
 	/**
+	 * Gets the slug of the post type that stores the blocks.
+	 *
+	 * @return string The slug.
+	 */
+	public function get_post_type_slug() {
+		return $this->post_type_slug;
+	}
+
+	/**
 	 * Set the plugin's slug.
 	 *
 	 * @param string $slug The slug.
@@ -245,14 +255,6 @@ abstract class Plugin_Abstract implements Plugin_Interface {
 		};
 
 		return $this;
-	}
-
-	/**
-	 * Instantiates the Util class, with utility methods.
-	 */
-	public function set_util() {
-		$this->util = new Util();
-		$this->register_component( $this->util );
 	}
 
 	/**

--- a/php/class-plugin-abstract.php
+++ b/php/class-plugin-abstract.php
@@ -54,14 +54,6 @@ abstract class Plugin_Abstract implements Plugin_Interface {
 	protected $slug;
 
 	/**
-	 * The slug of the post type that stores the blocks.
-	 *
-	 * @since 1.3.5
-	 * @var string
-	 */
-	protected $post_type_slug = 'block_lab';
-
-	/**
 	 * URL to the main plugin directory.
 	 *
 	 * @since 1.0.0
@@ -181,15 +173,6 @@ abstract class Plugin_Abstract implements Plugin_Interface {
 	 */
 	public function get_slug() {
 		return $this->slug;
-	}
-
-	/**
-	 * Gets the slug of the post type that stores the blocks.
-	 *
-	 * @return string The slug.
-	 */
-	public function get_post_type_slug() {
-		return $this->post_type_slug;
 	}
 
 	/**

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -13,6 +13,14 @@ namespace Block_Lab;
  * Class Plugin
  */
 class Plugin extends Plugin_Abstract {
+
+	/**
+	 * Utility methods.
+	 *
+	 * @var Util
+	 */
+	protected $util;
+
 	/**
 	 * WP Admin resources.
 	 *
@@ -21,30 +29,14 @@ class Plugin extends Plugin_Abstract {
 	public $admin;
 
 	/**
-	 * Block Post Type.
-	 *
-	 * @var Post_Types\Block_Post
-	 */
-	public $block_post;
-
-	/**
-	 * Initiate the loading of new blocks.
-	 *
-	 * @var Blocks\Loader
-	 */
-	public $loader;
-
-	/**
 	 * Execute this as early as possible.
 	 */
 	public function init() {
-		$this->set_util();
+		$this->util = new Util();
+		$this->register_component( $this->util );
 
-		$this->block_post = new Post_Types\Block_Post();
-		$this->register_component( $this->block_post );
-
-		$this->loader = new Blocks\Loader();
-		$this->register_component( $this->loader );
+		$this->register_component( new Post_Types\Block_Post() );
+		$this->register_component( new Blocks\Loader() );
 
 		register_activation_hook(
 			$this->get_file(),

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -29,6 +29,14 @@ class Plugin extends Plugin_Abstract {
 	public $admin;
 
 	/**
+	 * The slug of the post type that stores the blocks.
+	 *
+	 * @since 1.3.5
+	 * @var string
+	 */
+	protected $post_type_slug = 'block_lab';
+
+	/**
 	 * Execute this as early as possible.
 	 */
 	public function init() {

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -34,7 +34,7 @@ class Plugin extends Plugin_Abstract {
 	 * @since 1.3.5
 	 * @var string
 	 */
-	protected $post_type_slug = 'block_lab';
+	public $post_type_slug = 'block_lab';
 
 	/**
 	 * Execute this as early as possible.

--- a/php/class-util.php
+++ b/php/class-util.php
@@ -198,4 +198,13 @@ class Util extends Component_Abstract {
 		 */
 		return apply_filters( 'block_lab_allowed_svg_tags', $allowed_tags );
 	}
+
+	/**
+	 * Gets the slug of the post type that stores the blocks.
+	 *
+	 * @return string The slug.
+	 */
+	public function get_post_type_slug() {
+		return $this->plugin->post_type_slug;
+	}
 }

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -20,13 +20,6 @@ use Block_Lab\Blocks\Controls;
 class Block_Post extends Component_Abstract {
 
 	/**
-	 * Slug used for the custom post type.
-	 *
-	 * @var string
-	 */
-	public $slug = 'block_lab';
-
-	/**
 	 * Registered controls.
 	 *
 	 * @var Controls\Control_Abstract[]
@@ -66,12 +59,12 @@ class Block_Post extends Component_Abstract {
 		add_filter( 'block_lab_field_value', array( $this, 'get_field_value' ), 10, 3 );
 
 		// Clean up the list table.
-		add_filter( 'disable_months_dropdown', '__return_true', 10, $this->slug );
+		add_filter( 'disable_months_dropdown', '__return_true', 10, block_lab()->get_post_type_slug() );
 		add_filter( 'page_row_actions', array( $this, 'page_row_actions' ), 10, 1 );
-		add_filter( 'bulk_actions-edit-' . $this->slug, array( $this, 'bulk_actions' ) );
-		add_filter( 'handle_bulk_actions-edit-' . $this->slug, array( $this, 'bulk_export' ), 10, 3 );
-		add_filter( 'manage_edit-' . $this->slug . '_columns', array( $this, 'list_table_columns' ) );
-		add_action( 'manage_' . $this->slug . '_posts_custom_column', array( $this, 'list_table_content' ), 10, 2 );
+		add_filter( 'bulk_actions-edit-' . block_lab()->get_post_type_slug(), array( $this, 'bulk_actions' ) );
+		add_filter( 'handle_bulk_actions-edit-' . block_lab()->get_post_type_slug(), array( $this, 'bulk_export' ), 10, 3 );
+		add_filter( 'manage_edit-' . block_lab()->get_post_type_slug() . '_columns', array( $this, 'list_table_columns' ) );
+		add_action( 'manage_' . block_lab()->get_post_type_slug() . '_posts_custom_column', array( $this, 'list_table_content' ), 10, 2 );
 
 		// AJAX Handlers.
 		add_action( 'wp_ajax_fetch_field_settings', array( $this, 'ajax_field_settings' ) );
@@ -205,7 +198,7 @@ class Block_Post extends Component_Abstract {
 			),
 			// @codingStandardsIgnoreEnd
 			'query_var'     => true,
-			'rewrite'       => array( 'slug' => $this->slug ),
+			'rewrite'       => array( 'slug' => block_lab()->get_post_type_slug() ),
 			'hierarchical'  => true,
 			'capabilities'  => array(
 				'edit_post'          => 'block_lab_edit_block',
@@ -220,7 +213,7 @@ class Block_Post extends Component_Abstract {
 			'supports'      => array( 'title' ),
 		);
 
-		register_post_type( $this->slug, $args );
+		register_post_type( block_lab()->get_post_type_slug(), $args );
 	}
 
 	/**
@@ -254,7 +247,7 @@ class Block_Post extends Component_Abstract {
 		}
 
 		// Enqueue scripts and styles on the edit screen of the Block post type.
-		if ( $this->slug === $screen->post_type && 'post' === $screen->base ) {
+		if ( block_lab()->get_post_type_slug() === $screen->post_type && 'post' === $screen->base ) {
 			wp_enqueue_style(
 				'block-post',
 				$this->plugin->get_url( 'css/admin.block-post.css' ),
@@ -289,7 +282,7 @@ class Block_Post extends Component_Abstract {
 			);
 		}
 
-		if ( $this->slug === $screen->post_type && 'edit' === $screen->base ) {
+		if ( block_lab()->get_post_type_slug() === $screen->post_type && 'edit' === $screen->base ) {
 			wp_enqueue_style(
 				'block-edit',
 				$this->plugin->get_url( 'css/admin.block-edit.css' ),
@@ -311,7 +304,7 @@ class Block_Post extends Component_Abstract {
 			'block_properties',
 			__( 'Block Properties', 'block-lab' ),
 			array( $this, 'render_properties_meta_box' ),
-			$this->slug,
+			block_lab()->get_post_type_slug(),
 			'side',
 			'default'
 		);
@@ -320,7 +313,7 @@ class Block_Post extends Component_Abstract {
 			'block_fields',
 			__( 'Block Fields', 'block-lab' ),
 			array( $this, 'render_fields_meta_box' ),
-			$this->slug,
+			block_lab()->get_post_type_slug(),
 			'normal',
 			'default'
 		);
@@ -334,7 +327,7 @@ class Block_Post extends Component_Abstract {
 					'block_template',
 					__( 'Template', 'block-lab' ),
 					array( $this, 'render_template_meta_box' ),
-					$this->slug,
+					block_lab()->get_post_type_slug(),
 					'normal',
 					'high'
 				);
@@ -350,11 +343,11 @@ class Block_Post extends Component_Abstract {
 	public function remove_meta_boxes() {
 		$screen = get_current_screen();
 
-		if ( ! is_object( $screen ) || $this->slug !== $screen->post_type ) {
+		if ( ! is_object( $screen ) || block_lab()->get_post_type_slug() !== $screen->post_type ) {
 			return;
 		}
 
-		remove_meta_box( 'slugdiv', $this->slug, 'normal' );
+		remove_meta_box( 'slugdiv', block_lab()->get_post_type_slug(), 'normal' );
 	}
 
 	/**
@@ -366,7 +359,7 @@ class Block_Post extends Component_Abstract {
 		$post   = get_post();
 		$screen = get_current_screen();
 
-		if ( ! is_object( $screen ) || $this->slug !== $screen->post_type ) {
+		if ( ! is_object( $screen ) || block_lab()->get_post_type_slug() !== $screen->post_type ) {
 			return;
 		}
 
@@ -853,7 +846,7 @@ class Block_Post extends Component_Abstract {
 		$post   = get_post();
 		$screen = get_current_screen();
 
-		if ( ! is_object( $screen ) || $this->slug !== $screen->post_type ) {
+		if ( ! is_object( $screen ) || block_lab()->get_post_type_slug() !== $screen->post_type ) {
 			return;
 		}
 
@@ -946,7 +939,7 @@ class Block_Post extends Component_Abstract {
 		}
 
 		// Exits script if not the right post type.
-		if ( $data['post_type'] !== $this->slug ) {
+		if ( block_lab()->get_post_type_slug() !== $data['post_type'] ) {
 			return $data;
 		}
 
@@ -1154,7 +1147,7 @@ class Block_Post extends Component_Abstract {
 		$screen = get_current_screen();
 
 		// Enqueue scripts and styles on the edit screen of the Block post type.
-		if ( is_object( $screen ) && $this->slug === $screen->post_type ) {
+		if ( is_object( $screen ) && block_lab()->get_post_type_slug() === $screen->post_type ) {
 			$title = __( 'Enter block name here', 'block-lab' );
 		}
 
@@ -1243,7 +1236,7 @@ class Block_Post extends Component_Abstract {
 		$post = get_post();
 
 		// Abort if the post type is incorrect.
-		if ( $post->post_type !== $this->slug ) {
+		if ( block_lab()->get_post_type_slug() !== $post->post_type ) {
 			return $actions;
 		}
 

--- a/tests/php/post-types/test-class-block-post.php
+++ b/tests/php/post-types/test-class-block-post.php
@@ -23,6 +23,13 @@ class Test_Block_Post extends \WP_UnitTestCase {
 	public $instance;
 
 	/**
+	 * The expected slug.
+	 *
+	 * @var string
+	 */
+	const EXPECTED_SLUG = 'block_lab';
+
+	/**
 	 * Setup.
 	 *
 	 * @inheritdoc
@@ -57,10 +64,10 @@ class Test_Block_Post extends \WP_UnitTestCase {
 
 		$this->assertEquals( 10, has_action( 'disable_months_dropdown', '__return_true' ) );
 		$this->assertEquals( 10, has_action( 'page_row_actions', array( $this->instance, 'page_row_actions' ) ) );
-		$this->assertEquals( 10, has_action( 'bulk_actions-edit-' . $this->instance->slug, array( $this->instance, 'bulk_actions' ) ) );
-		$this->assertEquals( 10, has_action( 'handle_bulk_actions-edit-' . $this->instance->slug, array( $this->instance, 'bulk_export' ) ) );
-		$this->assertEquals( 10, has_action( 'manage_edit-' . $this->instance->slug . '_columns', array( $this->instance, 'list_table_columns' ) ) );
-		$this->assertEquals( 10, has_action( 'manage_' . $this->instance->slug . '_posts_custom_column', array( $this->instance, 'list_table_content' ) ) );
+		$this->assertEquals( 10, has_action( 'bulk_actions-edit-' . self::EXPECTED_SLUG, array( $this->instance, 'bulk_actions' ) ) );
+		$this->assertEquals( 10, has_action( 'handle_bulk_actions-edit-' . self::EXPECTED_SLUG, array( $this->instance, 'bulk_export' ) ) );
+		$this->assertEquals( 10, has_action( 'manage_edit-' . self::EXPECTED_SLUG . '_columns', array( $this->instance, 'list_table_columns' ) ) );
+		$this->assertEquals( 10, has_action( 'manage_' . self::EXPECTED_SLUG . '_posts_custom_column', array( $this->instance, 'list_table_content' ) ) );
 
 		$this->assertEquals( 10, has_action( 'wp_ajax_fetch_field_settings', array( $this->instance, 'ajax_field_settings' ) ) );
 	}
@@ -234,7 +241,7 @@ class Test_Block_Post extends \WP_UnitTestCase {
 		$block = $this->factory()->post->create(
 			array(
 				'post_title' => 'Test Block',
-				'post_type'  => $this->instance->slug,
+				'post_type'  => self::EXPECTED_SLUG,
 			)
 		);
 

--- a/tests/php/test-class-plugin.php
+++ b/tests/php/test-class-plugin.php
@@ -27,8 +27,27 @@ class Test_Plugin extends \WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->instance = new Block_Lab\Plugin();
+		$this->instance->init();
 		$this->instance->plugin_loaded();
-		$this->instance->set_util();
+	}
+
+	/**
+	 * Test init.
+	 *
+	 * @covers \Block_Lab\Abstract_Plugin:init()
+	 */
+	public function test_init() {
+		$plugin_instance = new Block_Lab\Plugin();
+		$plugin_instance->init();
+		$plugin_instance->plugin_loaded();
+
+		$reflection_plugin = new ReflectionObject( $this->instance );
+		$util_property     = $reflection_plugin->getProperty( 'util' );
+
+		$util_property->setAccessible( true );
+		$util_class = $util_property->getValue( $this->instance );
+
+		$this->assertEquals( 'Block_Lab\Util', get_class( $util_class ) );
 	}
 
 	/**
@@ -79,24 +98,5 @@ class Test_Plugin extends \WP_UnitTestCase {
 			),
 			$this->instance->get_template_locations( $name )
 		);
-	}
-
-	/**
-	 * Test set_util.
-	 *
-	 * @covers \Block_Lab\Abstract_Plugin:set_util()
-	 */
-	public function test_set_util() {
-		$plugin_instance = new Block_Lab\Plugin();
-		$plugin_instance->plugin_loaded();
-		$plugin_instance->set_util();
-
-		$reflection_plugin = new ReflectionObject( $this->instance );
-		$util_property     = $reflection_plugin->getProperty( 'util' );
-
-		$util_property->setAccessible( true );
-		$util_class = $util_property->getValue( $this->instance );
-
-		$this->assertEquals( 'Block_Lab\Util', get_class( $util_class ) );
 	}
 }

--- a/tests/php/test-class-util.php
+++ b/tests/php/test-class-util.php
@@ -13,6 +13,13 @@ class Test_Util extends Abstract_Template {
 	use Testing_Helper;
 
 	/**
+	 * The instance to test.
+	 *
+	 * @var Block_Lab\Util
+	 */
+	public $instance;
+
+	/**
 	 * Setup.
 	 *
 	 * @inheritdoc
@@ -21,7 +28,7 @@ class Test_Util extends Abstract_Template {
 		parent::setUp();
 
 		$this->instance = new Block_Lab\Util();
-		block_lab()->register_component( $this->instance );
+		$this->instance->set_plugin( block_lab() );
 	}
 
 	/**

--- a/tests/php/test-class-util.php
+++ b/tests/php/test-class-util.php
@@ -46,8 +46,8 @@ class Test_Util extends Abstract_Template {
 	 */
 	public function test_is_pro() {
 		$plugin_instance = new Block_Lab\Plugin();
+		$plugin_instance->init();
 		$plugin_instance->plugin_loaded();
-		$plugin_instance->set_util();
 
 		$plugin_instance->admin = new Block_Lab\Admin\Admin();
 		$plugin_instance->admin->init();

--- a/tests/php/test-class-util.php
+++ b/tests/php/test-class-util.php
@@ -254,4 +254,16 @@ class Test_Util extends Abstract_Template {
 		$svg_tags = $this->instance->allowed_svg_tags();
 		$this->assertEquals( $additional_tag_attributes, $svg_tags[ $additional_tag_name ] );
 	}
+
+	/**
+	 * Test get_post_type_slug.
+	 *
+	 * @covers \Block_Lab\Util::get_post_type_slug()
+	 */
+	public function test_get_post_type_slug() {
+		$this->assertEquals( 'block_lab', $this->instance->get_post_type_slug() );
+
+		// It should also be possible to call this via a magic method of the Plugin class.
+		$this->assertEquals( 'block_lab', block_lab()->get_post_type_slug() );
+	}
 }


### PR DESCRIPTION
* To follow the pattern of the `Plugin::init()` method, this moves the contents of `->set_util()` into that method, and deletes `->set_util()`
* Also, it adds a helper method `Plugin::get_post_type_slug()`
* This looks to remove the need to add `$block_post` as a property of Plugin
* This prevents `block_lab()->block_post` from essentially being in the global scope, so now people can't call something like `block_lab()->block_post->enqueue_scripts()` or `->add_caps()`