### PR TITLE
Make Import available without pro

### DIFF
--- a/php/admin/class-admin.php
+++ b/php/admin/class-admin.php
@@ -62,11 +62,9 @@ class Admin extends Component_Abstract {
 			$this->maybe_settings_redirect();
 		}
 
-		if ( block_lab()->is_pro() ) {
-			if ( defined( 'WP_LOAD_IMPORTERS' ) && WP_LOAD_IMPORTERS ) {
-				$this->import = new Import();
-				block_lab()->register_component( $this->import );
-			}
+		if ( defined( 'WP_LOAD_IMPORTERS' ) && WP_LOAD_IMPORTERS ) {
+			$this->import = new Import();
+			block_lab()->register_component( $this->import );
 		}
 	}
 


### PR DESCRIPTION
This PR make it possible to **Import** blocks using the base version of Block Lab.

To **Export** blocks, Pro is still needed.