### PR TITLE
Fix an issue in removing repeater rows

### DIFF
--- a/js/blocks/components/repeater-rows.js
+++ b/js/blocks/components/repeater-rows.js
@@ -164,7 +164,7 @@ import { Fields } from './';
 	 * @return {Object} The rows.
 	 */
 	getRows( attribute ) {
-		return ( attribute[ 'rows' ] ) ? attribute[ 'rows' ] : [ {} ];
+		return ( attribute && attribute[ 'rows' ] ) ? attribute[ 'rows' ] : [ {} ];
 	}
 
 	/**


### PR DESCRIPTION
* Checks that `attribute` is truthy before accessing a property
* There was a console error from running `removeRow()`
* This blocked actually removing it