### PR TITLE
Fix an issue where removing rows sometimes didn't work

### DIFF
--- a/js/blocks/components/repeater-rows.js
+++ b/js/blocks/components/repeater-rows.js
@@ -71,8 +71,8 @@ import { Fields } from './';
 		return () => {
 			const { parentBlockProps } = this.props;
 			const attr = { ...parentBlockProps.attributes };
-			const attribute = attr[ parentName ];
 			const parentName = this.getParent();
+			const attribute = attr[ parentName ];
 			const repeaterRows = this.getRows( attribute );
 
 			if ( ! repeaterRows ) {


### PR DESCRIPTION
* Before, removing repeater rows sometimes unexpectedly removed extra rows
* As Luke mentioned, it looks like this is from `parentName` being declared below its usage