### PR TITLE
Add a different admin notice for when the validation request fails

### DIFF
--- a/php/admin/class-license.php
+++ b/php/admin/class-license.php
@@ -177,10 +177,15 @@ class License extends Component_Abstract {
 	 */
 	public function license_request_failed_message() {
 		$message = sprintf(
-			/* translators: %s is the email link for support */
-			__( 'There was a problem activating the license, but it may not be invalid. If the problem persists, please <a href="%s">contact support</a>.', 'block-lab' ),
-			'mailto:hi@getblocklab.com?subject=There was a problem activating my Block Lab Pro license'
+			/* translators: %s is an HTML link to contact support */
+			__( 'There was a problem activating the license, but it may not be invalid. If the problem persists, please %s.', 'block-lab' ),
+			sprintf(
+				'<a href="%1$s">%2$s</a>',
+				'mailto:hi@getblocklab.com?subject=There was a problem activating my Block Lab Pro license',
+				esc_html__( 'contact support', 'block-lab' )
+			)
 		);
+
 		return sprintf( '<div class="notice notice-error"><p>%s</p></div>', wp_kses_post( $message ) );
 	}
 

--- a/php/admin/class-license.php
+++ b/php/admin/class-license.php
@@ -176,8 +176,12 @@ class License extends Component_Abstract {
 	 * @return string
 	 */
 	public function license_request_failed_message() {
-		$message = __( 'There was a problem activating the license, but it may not be invalid. Please either try again or contact support, mentioning this message.', 'block-lab' );
-		return sprintf( '<div class="notice notice-error"><p>%s</p></div>', esc_html( $message ) );
+		$message = sprintf(
+			/* translators: %s is the email link for support */
+			__( 'There was a problem activating the license, but it may not be invalid. If the problem persists, please <a href="%s">contact support</a>.', 'block-lab' ),
+			'mailto:hi@getblocklab.com?subject=There was a problem activating my Block Lab Pro license'
+		);
+		return sprintf( '<div class="notice notice-error"><p>%s</p></div>', wp_kses_post( $message ) );
 	}
 
 	/**

--- a/php/admin/class-license.php
+++ b/php/admin/class-license.php
@@ -30,6 +30,13 @@ class License extends Component_Abstract {
 	public $product_slug;
 
 	/**
+	 * The name of the license key transient.
+	 *
+	 * @var string
+	 */
+	const TRANSIENT_NAME = 'block_lab_license';
+
+	/**
 	 * The transient 'license' value for when the request to validate the Pro license failed.
 	 *
 	 * This is for when the actual POST request fails,
@@ -63,10 +70,15 @@ class License extends Component_Abstract {
 	 */
 	public function save_license_key( $key ) {
 		$this->activate_license( $key );
+		$license = get_transient( self::TRANSIENT_NAME );
 
 		if ( ! $this->is_valid() ) {
 			$key = '';
-			block_lab()->admin->settings->prepare_notice( $this->license_error_message() );
+			if ( isset( $license['license'] ) && self::REQUEST_FAILED === $license['license'] ) {
+				block_lab()->admin->settings->prepare_notice( $this->license_request_failed_message() );
+			} else {
+				block_lab()->admin->settings->prepare_notice( $this->license_invalid_message() );
+			}
 		} else {
 			block_lab()->admin->settings->prepare_notice( $this->license_success_message() );
 		}
@@ -97,13 +109,13 @@ class License extends Component_Abstract {
 	 * @return mixed
 	 */
 	public function get_license() {
-		$license = get_transient( 'block_lab_license' );
+		$license = get_transient( self::TRANSIENT_NAME );
 
 		if ( ! $license ) {
 			$key = get_option( 'block_lab_license_key' );
 			if ( ! empty( $key ) ) {
 				$this->activate_license( $key );
-				$license = get_transient( 'block_lab_license' );
+				$license = get_transient( self::TRANSIENT_NAME );
 			}
 		}
 
@@ -142,7 +154,7 @@ class License extends Component_Abstract {
 
 		$expiration = DAY_IN_SECONDS;
 
-		set_transient( 'block_lab_license', $license, $expiration );
+		set_transient( self::TRANSIENT_NAME, $license, $expiration );
 	}
 
 	/**
@@ -156,11 +168,24 @@ class License extends Component_Abstract {
 	}
 
 	/**
+	 * Admin notice for the license request failing.
+	 *
+	 * This is for when the validation request fails entirely, like with a 404.
+	 * Not for when it returns that the license is invalid.
+	 *
+	 * @return string
+	 */
+	public function license_request_failed_message() {
+		$message = __( 'There was a problem activating the license, but it may not be invalid. Please either try again or contact support, mentioning this message.', 'block-lab' );
+		return sprintf( '<div class="notice notice-error"><p>%s</p></div>', esc_html( $message ) );
+	}
+
+	/**
 	 * Admin notice for incorrect license details.
 	 *
 	 * @return string
 	 */
-	public function license_error_message() {
+	public function license_invalid_message() {
 		$message = __( 'There was a problem activating your Block Lab license.', 'block-lab' );
 		return sprintf( '<div class="notice notice-error"><p>%s</p></div>', esc_html( $message ) );
 	}

--- a/tests/php/unit/admin/test-class-license.php
+++ b/tests/php/unit/admin/test-class-license.php
@@ -55,7 +55,7 @@ class Test_License extends \WP_UnitTestCase {
 	 *
 	 * @var string
 	 */
-	const EXPECTED_LICENSE_REQUEST_FAILED_NOTICE = '<div class="notice notice-error"><p>There was a problem activating the license, but it may not be invalid. Please either try again or contact support, mentioning this message.</p></div>';
+	const EXPECTED_LICENSE_REQUEST_FAILED_NOTICE = '<div class="notice notice-error"><p>There was a problem activating the license, but it may not be invalid. If the problem persists, please <a href="mailto:hi@getblocklab.com?subject=There was a problem activating my Block Lab Pro license">contact support</a>.</p></div>';
 
 	/**
 	 * The notice for when the license is invalid.
@@ -113,9 +113,6 @@ class Test_License extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Admin\License::init()
 	 */
 	public function test_init() {
-		$this->store_url    = 'https://getblocklab.com';
-		$this->product_slug = 'block-lab-pro';
-
 		// Before init() is called, these properties should not have values.
 		$this->assertEmpty( $this->instance->store_url );
 		$this->assertEmpty( $this->instance->product_slug );

--- a/tests/php/unit/admin/test-class-license.php
+++ b/tests/php/unit/admin/test-class-license.php
@@ -51,6 +51,27 @@ class Test_License extends \WP_UnitTestCase {
 	const HTTP_FILTER_NAME = 'pre_http_request';
 
 	/**
+	 * The notice for when the validation request fails.
+	 *
+	 * @var string
+	 */
+	const EXPECTED_LICENSE_REQUEST_FAILED_NOTICE = '<div class="notice notice-error"><p>There was a problem activating the license, but it may not be invalid. Please either try again or contact support, mentioning this message.</p></div>';
+
+	/**
+	 * The notice for when the license is invalid.
+	 *
+	 * @var string
+	 */
+	const EXPECTED_LICENSE_INVALID_NOTICE = '<div class="notice notice-error"><p>There was a problem activating your Block Lab license.</p></div>';
+
+	/**
+	 * The notice for when the license validation succeeds.
+	 *
+	 * @var string
+	 */
+	const EXPECTED_LICENSE_SUCCESS_NOTICE = '<div class="notice notice-success"><p>Your Block Lab license was successfully activated!</p></div>';
+
+	/**
 	 * Setup.
 	 *
 	 * @inheritdoc
@@ -112,17 +133,34 @@ class Test_License extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Admin\License::save_license_key()
 	 */
 	public function test_save_license_key() {
-		$this->set_license_validity( false );
 		$mock_invalid_license_key = '0000000';
 		$returned_key             = $this->instance->save_license_key( $mock_invalid_license_key );
 
-		// For an invalid license, the method should return '', and the notice should be an error.
+		// For the request failing, like with a 404, the method should return '', and the notice should be to retry or contact support.
 		$this->assertEquals( '', $returned_key );
 		$this->assertEquals(
-			array( '<div class="notice notice-error"><p>There was a problem activating your Block Lab license.</p></div>' ),
+			array( self::EXPECTED_LICENSE_REQUEST_FAILED_NOTICE ),
 			get_option( self::NOTICES_OPTION_NAME )
 		);
 		delete_option( self::NOTICES_OPTION_NAME );
+
+		// Cause the validation request to return that the license is valid.
+		add_filter(
+			self::HTTP_FILTER_NAME,
+			function() {
+				return array( 'body' => wp_json_encode( array( 'license' => 'invalid' ) ) );
+			}
+		);
+		$returned_key = $this->instance->save_license_key( $mock_invalid_license_key );
+
+		// For an invalid license (not simply the request failing), the method should return '', and the notice should be an error.
+		$this->assertEquals( '', $returned_key );
+		$this->assertEquals(
+			array( self::EXPECTED_LICENSE_INVALID_NOTICE ),
+			get_option( self::NOTICES_OPTION_NAME )
+		);
+		delete_option( self::NOTICES_OPTION_NAME );
+		remove_all_filters( self::HTTP_FILTER_NAME );
 
 		$expected_license = array(
 			'license' => 'valid',
@@ -141,7 +179,7 @@ class Test_License extends \WP_UnitTestCase {
 		$returned_key           = $this->instance->save_license_key( $mock_valid_license_key );
 		$this->assertEquals( $mock_valid_license_key, $returned_key );
 		$this->assertEquals(
-			array( '<div class="notice notice-success"><p>Your Block Lab license was successfully activated!</p></div>' ),
+			array( self::EXPECTED_LICENSE_SUCCESS_NOTICE ),
 			get_option( self::NOTICES_OPTION_NAME )
 		);
 	}
@@ -244,8 +282,7 @@ class Test_License extends \WP_UnitTestCase {
 		$license_key = '6234234';
 		add_filter(
 			self::HTTP_FILTER_NAME,
-			function( $response ) {
-				unset( $response );
+			function() {
 				return new WP_Error();
 			}
 		);
@@ -265,8 +302,7 @@ class Test_License extends \WP_UnitTestCase {
 
 		add_filter(
 			self::HTTP_FILTER_NAME,
-			function( $response ) use ( $expected_license ) {
-				unset( $response );
+			function() use ( $expected_license ) {
 				return array( 'body' => wp_json_encode( $expected_license ) );
 			}
 		);
@@ -283,20 +319,32 @@ class Test_License extends \WP_UnitTestCase {
 	 */
 	public function test_license_success_message() {
 		$this->assertEquals(
-			'<div class="notice notice-success"><p>Your Block Lab license was successfully activated!</p></div>',
+			self::EXPECTED_LICENSE_SUCCESS_NOTICE,
 			$this->instance->license_success_message()
 		);
 	}
 
 	/**
-	 * Test license_error_message.
+	 * Test license_request_failed_message.
 	 *
-	 * @covers \Block_Lab\Admin\License::license_error_message()
+	 * @covers \Block_Lab\Admin\License::license_request_failed_message()
 	 */
-	public function test_license_error_message() {
+	public function test_license_request_failed_message() {
 		$this->assertEquals(
-			'<div class="notice notice-error"><p>There was a problem activating your Block Lab license.</p></div>',
-			$this->instance->license_error_message()
+			self::EXPECTED_LICENSE_REQUEST_FAILED_NOTICE,
+			$this->instance->license_request_failed_message()
+		);
+	}
+
+	/**
+	 * Test license_invalid_message.
+	 *
+	 * @covers \Block_Lab\Admin\License::license_invalid_message()
+	 */
+	public function test_license_invalid_message() {
+		$this->assertEquals(
+			self::EXPECTED_LICENSE_INVALID_NOTICE,
+			$this->instance->license_invalid_message()
 		);
 	}
 }


### PR DESCRIPTION
A follow-up to #398 

This displays a message for the case that we saw on Saturday, where the validation request failed (like with a 404).

<img width="989" alt="support-request-failed" src="https://user-images.githubusercontent.com/4063887/63905364-a7188900-c9d9-11e9-9ea7-d3a2e3456619.png">

>There was a problem activating the license, but it may not be invalid. Please either try again or contact support, mentioning this message.

However, this will only display when the user clicks 'Save Changes' on the Block Lab Settings page below. It won't appear when this makes the daily request to `getblocklab.com` to continue verifying the license. 

That's probably a more common case, as users probably only save their license once, where it makes another request every day.

This is a different case from it being an invalid license, and I think it  should have different feedback. It means our site might be down, and we should have that information right away.

# Steps to test
1. Simulate the validation POST request failing, by setting the URL of the request to one that doesn't exist:

```diff
diff --git a/php/admin/class-license.php b/php/admin/class-license.php
index 66b79df..68e4325 100644
--- a/php/admin/class-license.php
+++ b/php/admin/class-license.php
@@ -43,7 +43,7 @@ class License extends Component_Abstract {
         * Initialise the Pro component.
         */
        public function init() {
-               $this->store_url    = 'https://getblocklab.com';
+               $this->store_url    = 'https://nonexistent-site-here.com';
                $this->product_slug = 'block-lab-pro';
```

2. Delete the transient:

```sh
wp transient delete block_lab_license
```

3. Click 'Save Changes' for the license:

<img width="989" alt="support-request-failed" src="https://user-images.githubusercontent.com/4063887/63905847-25295f80-c9db-11e9-9c05-817b7130e72b.png">
