### PR TITLE
Add a field width control to blocks

### DIFF
--- a/css/admin.block-post.css
+++ b/css/admin.block-post.css
@@ -189,6 +189,38 @@
 #block_fields .block-fields-rows textarea[readonly="readonly"] {
     color: #999;
 }
+#block_fields .block-fields-rows .button-group > .button {
+	width: 5em;
+	position: relative;
+	z-index: 10;
+}
+#block_fields .block-fields-rows .button-group > .button:last-of-type {
+	border-radius: 0 3px 3px 0;
+}
+#block_fields .block-fields-rows .button-group > .button:hover {
+	z-index: 30;
+}
+#block_fields .block-fields-rows .button-group > .button:checked {
+	background: #eee;
+	border-color: #999;
+	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5), 0 1px 0 #cccccc;
+	z-index: 20;
+}
+#block_fields .block-fields-rows .button-group > .button:checked:before {
+	width: 0;
+	height: 0;
+	background-color: transparent;
+}
+#block_fields .block-fields-rows .button-group > label {
+	font-size: 13px;
+	position: absolute;
+	margin-left: -5em;
+	width: 5em;
+	top: 13px;
+	text-align: center;
+	pointer-events: none;
+	z-index: 40;
+}
 #block_fields .block-fields-rows .block-fields-edit-loading .loading:before {
 	content: '';
 	box-sizing: border-box;

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -109,13 +109,16 @@ div[class^="wp-block-block-lab-"] {
   .block-form {
     border-left: none;
     background: $dark-opacity-light-200;
-    padding: 22px;
+    padding: 22px 0 22px 22px;
     font-size: 0.8125rem;
+    display: flex;
+    flex-wrap: wrap;
 
     h3 {
       color: #111;
       font-size: 1rem;
       margin: 0;
+      flex: 1 1 100%;
 
       svg {
         position: relative;
@@ -126,6 +129,29 @@ div[class^="wp-block-block-lab-"] {
 
     p {
       font-size: 1rem;
+    }
+
+    .block-lab-control {
+      flex-basis: 100%;
+      padding-right: 22px;
+
+      &.width-25 {
+        flex-basis: 25%;
+      }
+      &.width-50 {
+        flex-basis: 50%;
+      }
+      &.width-75 {
+        flex-basis: 75%;
+      }
+    }
+
+    @media screen and (max-width: 782px) {
+      .block-lab-control.width-25,
+      .block-lab-control.width-50,
+      .block-lab-control.width-75 {
+        flex-basis: 100%;
+      }
     }
 
     .components-base-control__field {

--- a/js/admin.block-post.js
+++ b/js/admin.block-post.js
@@ -160,6 +160,7 @@
 					$( '.block-fields-rows .block-fields-row-active' ).removeClass( 'block-fields-row-active' );
 				}
 
+				blockFieldWidthInit( currentRow );
 				currentRow.toggleClass( 'block-fields-row-active' );
 				currentRow.find( '.block-fields-edit' ).first().slideToggle();
 
@@ -197,6 +198,9 @@
 				} else {
 					$( '.block-fields-sub-rows,.block-fields-sub-rows-actions', fieldRow ).remove();
 				}
+			})
+			.on( 'change', '.block-fields-edit-location-settings select', function() {
+				blockFieldWidthInit( $( this ).closest( '.block-fields-row' ) );
 			})
 			.on( 'change keyup', '.block-fields-edit-label input', function() {
 				let slug = $( this )
@@ -285,6 +289,17 @@
 		});
 	}
 
+	let blockFieldWidthInit = function( fieldRow ) {
+		let widthSettings    = fieldRow.find( '.block-fields-edit-width-settings' ),
+			locationSettings = fieldRow.find( '.block-fields-edit-location-settings' );
+
+		if ( 'editor' !== $( 'select', locationSettings ).val() ) {
+			widthSettings.hide();
+		} else {
+			widthSettings.show();
+		}
+	}
+
 	let blockPostTypesInit = function() {
 		if ( 0 === $( '.block-lab-pub-section' ).length ) {
 			return;
@@ -356,6 +371,7 @@
 				}
 				let settingsRows = $( data.html );
 				$( '.block-fields-edit-control', fieldRow ).after( settingsRows );
+				blockFieldWidthInit( fieldRow );
 				scrollRowIntoView( fieldRow );
 			},
 			error: function() {

--- a/js/blocks/components/edit.js
+++ b/js/blocks/components/edit.js
@@ -32,9 +32,7 @@ const Edit = ( { blockProps, block } ) => {
 				{ isSelected ? (
 					<div className="block-form">
 						<h3 dangerouslySetInnerHTML={ { __html: icons[ block.icon ] + ' ' + block.title } } />
-						<div>
-							<FormControls blockProps={ blockProps } block={ block } />
-						</div>
+						<FormControls blockProps={ blockProps } block={ block } />
 					</div>
 				) : (
 					<ServerSideRender

--- a/js/blocks/components/fields.js
+++ b/js/blocks/components/fields.js
@@ -21,6 +21,22 @@ const getControl = ( field ) => {
 };
 
 /**
+ * Gets the class name for the field.
+ *
+ * @param {Object} field The field to get the class name of.
+ * @return {string} The class name.
+ */
+const getClassName = ( field ) => {
+	let className = 'block-lab-control';
+
+	if ( field.width ) {
+		className += ' width-' + field.width;
+	}
+
+	return className;
+};
+
+/**
  * Renders the fields, using their control functions.
  *
  * @param {Array}  fields           The fields to render.
@@ -99,15 +115,17 @@ const Fields = ( { fields, parentBlockProps, parentBlock, rowIndex } ) => {
 		}
 
 		return (
-			<Control
-				key={ `${ field.name }-control-${ rowIndex }` }
-				field={ field }
-				getValue={ getValue }
-				onChange={ onChange }
-				parentBlock={ parentBlock }
-				rowIndex={ rowIndex }
-				parentBlockProps={ parentBlockProps }
-			/>
+			<div className={getClassName( field )}>
+				<Control
+					key={ `${ field.name }-control-${ rowIndex }` }
+					field={ field }
+					getValue={ getValue }
+					onChange={ onChange }
+					parentBlock={ parentBlock }
+					rowIndex={ rowIndex }
+					parentBlockProps={ parentBlockProps }
+				/>
+			</div>
 		);
 	} );
 };

--- a/php/blocks/controls/class-checkbox.php
+++ b/php/blocks/controls/class-checkbox.php
@@ -45,6 +45,7 @@ class Checkbox extends Control_Abstract {
 	 */
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( $this->settings_config['location'] );
+		$this->settings[] = new Control_Setting( $this->settings_config['width'] );
 		$this->settings[] = new Control_Setting( $this->settings_config['help'] );
 		$this->settings[] = new Control_Setting(
 			array(

--- a/php/blocks/controls/class-color.php
+++ b/php/blocks/controls/class-color.php
@@ -37,8 +37,17 @@ class Color extends Control_Abstract {
 	 * @return void
 	 */
 	public function register_settings() {
-		foreach ( array( 'location', 'help', 'default' ) as $setting ) {
-			$this->settings[] = new Control_Setting( $this->settings_config[ $setting ] );
-		}
+		$this->settings[] = new Control_Setting( $this->settings_config['location'] );
+		$this->settings[] = new Control_Setting(
+			array(
+				'name'     => 'width',
+				'label'    => __( 'Field Width', 'block-lab' ),
+				'type'     => 'width',
+				'default'  => '25',
+				'sanitize' => 'sanitize_text_field',
+			)
+		);
+		$this->settings[] = new Control_Setting( $this->settings_config['help'] );
+		$this->settings[] = new Control_Setting( $this->settings_config['default'] );
 	}
 }

--- a/php/blocks/controls/class-color.php
+++ b/php/blocks/controls/class-color.php
@@ -37,17 +37,8 @@ class Color extends Control_Abstract {
 	 * @return void
 	 */
 	public function register_settings() {
-		$this->settings[] = new Control_Setting( $this->settings_config['location'] );
-		$this->settings[] = new Control_Setting(
-			array(
-				'name'     => 'width',
-				'label'    => __( 'Field Width', 'block-lab' ),
-				'type'     => 'width',
-				'default'  => '25',
-				'sanitize' => 'sanitize_text_field',
-			)
-		);
-		$this->settings[] = new Control_Setting( $this->settings_config['help'] );
-		$this->settings[] = new Control_Setting( $this->settings_config['default'] );
+		foreach ( array( 'location', 'width', 'help', 'default' ) as $setting ) {
+			$this->settings[] = new Control_Setting( $this->settings_config[ $setting ] );
+		}
 	}
 }

--- a/php/blocks/controls/class-control-abstract.php
+++ b/php/blocks/controls/class-control-abstract.php
@@ -83,6 +83,13 @@ abstract class Control_Abstract {
 	 */
 	public function create_settings_config() {
 		$this->settings_config = array(
+			'field_width' => array(
+				'name'     => 'field_width',
+				'label'    => __( 'Field Width', 'block-lab' ),
+				'type'     => 'field_width',
+				'default'  => '100',
+				'sanitize' => 'sanitize_text_field',
+			),
 			'location'    => array(
 				'name'     => 'location',
 				'label'    => __( 'Location', 'block-lab' ),
@@ -138,6 +145,11 @@ abstract class Control_Abstract {
 		foreach ( $this->settings as $setting ) {
 			// Don't render the location setting for sub-fields.
 			if ( 'location' === $setting->type && isset( $field->settings['parent'] ) ) {
+				continue;
+			}
+
+			// Don't render the location setting for sub-fields.
+			if ( 'field_width' === $setting->type && isset( $field->settings['parent'] ) ) {
 				continue;
 			}
 
@@ -335,6 +347,42 @@ abstract class Control_Abstract {
 	 */
 	public function render_settings_location( $setting, $name, $id ) {
 		$this->render_select( $setting, $name, $id, $this->locations );
+	}
+
+	/**
+	 * Renders a button group of field widths.
+	 *
+	 * @param Control_Setting $setting The Control_Setting being rendered.
+	 * @param string          $name    The name attribute of the option.
+	 * @param string          $id      The id attribute of the option.
+	 *
+	 * @return void
+	 */
+	public function render_settings_field_width( $setting, $name, $id ) {
+		$widths = array(
+			'25'  => '25%',
+			'50'  => '50%',
+			'75'  => '75%',
+			'100' => '100%',
+		);
+		?>
+		<div class="field-width button-group">
+		<?php
+		foreach ( $widths as $value => $label ) {
+			?>
+			<input
+				class="button"
+				name="<?php echo esc_attr( $name ); ?>"
+				type="radio"
+				value="<?php echo esc_attr( $value ); ?>"
+				<?php checked( $value, $setting->get_value() ); ?>
+				/>
+			<label><?php echo esc_html( $label ); ?></label>
+			<?php
+		}
+		?>
+		</div>
+		<?php
 	}
 
 	/**

--- a/php/blocks/controls/class-control-abstract.php
+++ b/php/blocks/controls/class-control-abstract.php
@@ -83,19 +83,19 @@ abstract class Control_Abstract {
 	 */
 	public function create_settings_config() {
 		$this->settings_config = array(
-			'field_width' => array(
-				'name'     => 'field_width',
-				'label'    => __( 'Field Width', 'block-lab' ),
-				'type'     => 'field_width',
-				'default'  => '100',
-				'sanitize' => 'sanitize_text_field',
-			),
 			'location'    => array(
 				'name'     => 'location',
-				'label'    => __( 'Location', 'block-lab' ),
+				'label'    => __( 'Field Location', 'block-lab' ),
 				'type'     => 'location',
 				'default'  => 'editor',
 				'sanitize' => array( $this, 'sanitize_location' ),
+			),
+			'width'       => array(
+				'name'     => 'width',
+				'label'    => __( 'Field Width', 'block-lab' ),
+				'type'     => 'width',
+				'default'  => '100',
+				'sanitize' => 'sanitize_text_field',
 			),
 			'help'        => array(
 				'name'     => 'help',
@@ -358,7 +358,7 @@ abstract class Control_Abstract {
 	 *
 	 * @return void
 	 */
-	public function render_settings_field_width( $setting, $name, $id ) {
+	public function render_settings_width( $setting, $name, $id ) {
 		$widths = array(
 			'25'  => '25%',
 			'50'  => '50%',
@@ -366,7 +366,7 @@ abstract class Control_Abstract {
 			'100' => '100%',
 		);
 		?>
-		<div class="field-width button-group">
+		<div class="button-group">
 		<?php
 		foreach ( $widths as $value => $label ) {
 			?>

--- a/php/blocks/controls/class-email.php
+++ b/php/blocks/controls/class-email.php
@@ -38,6 +38,7 @@ class Email extends Control_Abstract {
 	 */
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( $this->settings_config['location'] );
+		$this->settings[] = new Control_Setting( $this->settings_config['width'] );
 		$this->settings[] = new Control_Setting( $this->settings_config['help'] );
 		$this->settings[] = new Control_Setting(
 			array(

--- a/php/blocks/controls/class-image.php
+++ b/php/blocks/controls/class-image.php
@@ -44,7 +44,7 @@ class Image extends Control_Abstract {
 	 * @return void
 	 */
 	public function register_settings() {
-		foreach ( array( 'location', 'help' ) as $setting ) {
+		foreach ( array( 'location', 'width', 'help' ) as $setting ) {
 			$this->settings[] = new Control_Setting( $this->settings_config[ $setting ] );
 		}
 	}

--- a/php/blocks/controls/class-multiselect.php
+++ b/php/blocks/controls/class-multiselect.php
@@ -45,6 +45,7 @@ class Multiselect extends Control_Abstract {
 	 */
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( $this->settings_config['location'] );
+		$this->settings[] = new Control_Setting( $this->settings_config['width'] );
 		$this->settings[] = new Control_Setting( $this->settings_config['help'] );
 		$this->settings[] = new Control_Setting(
 			array(

--- a/php/blocks/controls/class-number.php
+++ b/php/blocks/controls/class-number.php
@@ -45,6 +45,7 @@ class Number extends Control_Abstract {
 	 */
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( $this->settings_config['location'] );
+		$this->settings[] = new Control_Setting( $this->settings_config['width'] );
 		$this->settings[] = new Control_Setting( $this->settings_config['help'] );
 		$this->settings[] = new Control_Setting(
 			array(

--- a/php/blocks/controls/class-post.php
+++ b/php/blocks/controls/class-post.php
@@ -43,6 +43,7 @@ class Post extends Control_Abstract {
 	 */
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( $this->settings_config['location'] );
+		$this->settings[] = new Control_Setting( $this->settings_config['width'] );
 		$this->settings[] = new Control_Setting( $this->settings_config['help'] );
 		$this->settings[] = new Control_Setting(
 			array(

--- a/php/blocks/controls/class-radio.php
+++ b/php/blocks/controls/class-radio.php
@@ -38,6 +38,7 @@ class Radio extends Control_Abstract {
 	 */
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( $this->settings_config['location'] );
+		$this->settings[] = new Control_Setting( $this->settings_config['width'] );
 		$this->settings[] = new Control_Setting( $this->settings_config['help'] );
 		$this->settings[] = new Control_Setting(
 			array(

--- a/php/blocks/controls/class-range.php
+++ b/php/blocks/controls/class-range.php
@@ -45,6 +45,7 @@ class Range extends Control_Abstract {
 	 */
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( $this->settings_config['location'] );
+		$this->settings[] = new Control_Setting( $this->settings_config['width'] );
 		$this->settings[] = new Control_Setting( $this->settings_config['help'] );
 		$this->settings[] = new Control_Setting(
 			array(

--- a/php/blocks/controls/class-select.php
+++ b/php/blocks/controls/class-select.php
@@ -38,6 +38,7 @@ class Select extends Control_Abstract {
 	 */
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( $this->settings_config['location'] );
+		$this->settings[] = new Control_Setting( $this->settings_config['width'] );
 		$this->settings[] = new Control_Setting( $this->settings_config['help'] );
 		$this->settings[] = new Control_Setting(
 			array(

--- a/php/blocks/controls/class-taxonomy.php
+++ b/php/blocks/controls/class-taxonomy.php
@@ -43,6 +43,7 @@ class Taxonomy extends Control_Abstract {
 	 */
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( $this->settings_config['location'] );
+		$this->settings[] = new Control_Setting( $this->settings_config['width'] );
 		$this->settings[] = new Control_Setting( $this->settings_config['help'] );
 		$this->settings[] = new Control_Setting(
 			array(

--- a/php/blocks/controls/class-text.php
+++ b/php/blocks/controls/class-text.php
@@ -37,7 +37,7 @@ class Text extends Control_Abstract {
 	 * @return void
 	 */
 	public function register_settings() {
-		foreach ( array( 'location', 'help', 'default', 'placeholder' ) as $setting ) {
+		foreach ( array( 'location', 'width', 'help', 'default', 'placeholder' ) as $setting ) {
 			$this->settings[] = new Control_Setting( $this->settings_config[ $setting ] );
 		}
 

--- a/php/blocks/controls/class-textarea.php
+++ b/php/blocks/controls/class-textarea.php
@@ -44,7 +44,7 @@ class Textarea extends Control_Abstract {
 	 * @return void
 	 */
 	public function register_settings() {
-		foreach ( array( 'location', 'help' ) as $setting ) {
+		foreach ( array( 'location', 'width', 'help' ) as $setting ) {
 			$this->settings[] = new Control_Setting( $this->settings_config[ $setting ] );
 		}
 

--- a/php/blocks/controls/class-toggle.php
+++ b/php/blocks/controls/class-toggle.php
@@ -45,6 +45,7 @@ class Toggle extends Control_Abstract {
 	 */
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( $this->settings_config['location'] );
+		$this->settings[] = new Control_Setting( $this->settings_config['width'] );
 		$this->settings[] = new Control_Setting( $this->settings_config['help'] );
 		$this->settings[] = new Control_Setting(
 			array(

--- a/php/blocks/controls/class-url.php
+++ b/php/blocks/controls/class-url.php
@@ -38,6 +38,7 @@ class Url extends Control_Abstract {
 	 */
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( $this->settings_config['location'] );
+		$this->settings[] = new Control_Setting( $this->settings_config['width'] );
 		$this->settings[] = new Control_Setting( $this->settings_config['help'] );
 		$this->settings[] = new Control_Setting(
 			array(

--- a/php/blocks/controls/class-user.php
+++ b/php/blocks/controls/class-user.php
@@ -42,7 +42,7 @@ class User extends Control_Abstract {
 	 * @return void
 	 */
 	public function register_settings() {
-		foreach ( array( 'location', 'help' ) as $setting ) {
+		foreach ( array( 'location', 'width', 'help' ) as $setting ) {
 			$this->settings[] = new Control_Setting( $this->settings_config[ $setting ] );
 		}
 	}

--- a/tests/php/unit/blocks/controls/test-class-checkbox.php
+++ b/tests/php/unit/blocks/controls/test-class-checkbox.php
@@ -52,11 +52,21 @@ class Test_Checkbox extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',
 				'sanitize' => array( $this->instance, 'sanitize_location' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
 				'validate' => '',
 				'value'    => null,
 			),

--- a/tests/php/unit/blocks/controls/test-class-color.php
+++ b/tests/php/unit/blocks/controls/test-class-color.php
@@ -52,11 +52,21 @@ class Test_Color extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',
 				'sanitize' => array( $this->instance, 'sanitize_location' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
 				'validate' => '',
 				'value'    => null,
 			),

--- a/tests/php/unit/blocks/controls/test-class-control-abstract.php
+++ b/tests/php/unit/blocks/controls/test-class-control-abstract.php
@@ -61,10 +61,17 @@ class Test_Control_Abstract extends \WP_UnitTestCase {
 			array(
 				'location'    => array(
 					'name'     => 'location',
-					'label'    => __( 'Location', 'block-lab' ),
+					'label'    => __( 'Field Location', 'block-lab' ),
 					'type'     => 'location',
 					'default'  => 'editor',
 					'sanitize' => array( $this->instance, 'sanitize_location' ),
+				),
+				'width'       => array(
+					'name'     => 'width',
+					'label'    => __( 'Field Width', 'block-lab' ),
+					'type'     => 'width',
+					'default'  => '100',
+					'sanitize' => 'sanitize_text_field',
 				),
 				'help'        => array(
 					'name'     => 'help',

--- a/tests/php/unit/blocks/controls/test-class-email.php
+++ b/tests/php/unit/blocks/controls/test-class-email.php
@@ -52,11 +52,21 @@ class Test_Email extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',
 				'sanitize' => array( $this->instance, 'sanitize_location' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
 				'validate' => '',
 				'value'    => null,
 			),

--- a/tests/php/unit/blocks/controls/test-class-image.php
+++ b/tests/php/unit/blocks/controls/test-class-image.php
@@ -59,6 +59,16 @@ class Test_Image extends \WP_UnitTestCase {
 				'value'    => null,
 			),
 			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
 				'name'     => 'help',
 				'label'    => 'Help Text',
 				'type'     => 'text',

--- a/tests/php/unit/blocks/controls/test-class-image.php
+++ b/tests/php/unit/blocks/controls/test-class-image.php
@@ -50,7 +50,7 @@ class Test_Image extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',

--- a/tests/php/unit/blocks/controls/test-class-multiselect.php
+++ b/tests/php/unit/blocks/controls/test-class-multiselect.php
@@ -52,11 +52,21 @@ class Test_Multiselect extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',
 				'sanitize' => array( $this->instance, 'sanitize_location' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
 				'validate' => '',
 				'value'    => null,
 			),

--- a/tests/php/unit/blocks/controls/test-class-number.php
+++ b/tests/php/unit/blocks/controls/test-class-number.php
@@ -60,11 +60,21 @@ class Test_Number extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',
 				'sanitize' => array( $this->instance, 'sanitize_location' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
 				'validate' => '',
 				'value'    => null,
 			),

--- a/tests/php/unit/blocks/controls/test-class-post.php
+++ b/tests/php/unit/blocks/controls/test-class-post.php
@@ -58,11 +58,21 @@ class Test_Post extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',
 				'sanitize' => array( $this->instance, 'sanitize_location' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
 				'validate' => '',
 				'value'    => null,
 			),

--- a/tests/php/unit/blocks/controls/test-class-radio.php
+++ b/tests/php/unit/blocks/controls/test-class-radio.php
@@ -52,11 +52,21 @@ class Test_Radio extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',
 				'sanitize' => array( $this->instance, 'sanitize_location' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
 				'validate' => '',
 				'value'    => null,
 			),

--- a/tests/php/unit/blocks/controls/test-class-range.php
+++ b/tests/php/unit/blocks/controls/test-class-range.php
@@ -52,11 +52,21 @@ class Test_Range extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',
 				'sanitize' => array( $this->instance, 'sanitize_location' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
 				'validate' => '',
 				'value'    => null,
 			),

--- a/tests/php/unit/blocks/controls/test-class-select.php
+++ b/tests/php/unit/blocks/controls/test-class-select.php
@@ -52,11 +52,21 @@ class Test_Select extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',
 				'sanitize' => array( $this->instance, 'sanitize_location' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
 				'validate' => '',
 				'value'    => null,
 			),

--- a/tests/php/unit/blocks/controls/test-class-taxonomy.php
+++ b/tests/php/unit/blocks/controls/test-class-taxonomy.php
@@ -58,11 +58,21 @@ class Test_Taxonomy extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',
 				'sanitize' => array( $this->instance, 'sanitize_location' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
 				'validate' => '',
 				'value'    => null,
 			),

--- a/tests/php/unit/blocks/controls/test-class-text.php
+++ b/tests/php/unit/blocks/controls/test-class-text.php
@@ -52,11 +52,21 @@ class Test_Text extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',
 				'sanitize' => array( $this->instance, 'sanitize_location' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
 				'validate' => '',
 				'value'    => null,
 			),

--- a/tests/php/unit/blocks/controls/test-class-textarea.php
+++ b/tests/php/unit/blocks/controls/test-class-textarea.php
@@ -60,11 +60,21 @@ class Test_Textarea extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',
 				'sanitize' => array( $this->instance, 'sanitize_location' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
 				'validate' => '',
 				'value'    => null,
 			),

--- a/tests/php/unit/blocks/controls/test-class-toggle.php
+++ b/tests/php/unit/blocks/controls/test-class-toggle.php
@@ -52,11 +52,21 @@ class Test_Toggle extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',
 				'sanitize' => array( $this->instance, 'sanitize_location' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
 				'validate' => '',
 				'value'    => null,
 			),

--- a/tests/php/unit/blocks/controls/test-class-url.php
+++ b/tests/php/unit/blocks/controls/test-class-url.php
@@ -52,11 +52,21 @@ class Test_Url extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',
 				'sanitize' => array( $this->instance, 'sanitize_location' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
 				'validate' => '',
 				'value'    => null,
 			),

--- a/tests/php/unit/blocks/controls/test-class-user.php
+++ b/tests/php/unit/blocks/controls/test-class-user.php
@@ -50,11 +50,21 @@ class Test_User extends \WP_UnitTestCase {
 		$expected_settings = array(
 			array(
 				'name'     => 'location',
-				'label'    => 'Location',
+				'label'    => 'Field Location',
 				'type'     => 'location',
 				'default'  => 'editor',
 				'help'     => '',
 				'sanitize' => array( $this->instance, 'sanitize_location' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'width',
+				'label'    => 'Field Width',
+				'type'     => 'width',
+				'default'  => '100',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
 				'validate' => '',
 				'value'    => null,
 			),


### PR DESCRIPTION
This doesn't yet work for repeater rows, but it will be easy to add. I'd suggest merging this one in, and doing repeater later.

Please test on all controls! @RobStino could use your help for this!

![Screen Shot 2019-08-30 at 4 00 35 pm](https://user-images.githubusercontent.com/1097667/63996547-53c04b00-cb3f-11e9-85f6-a7750ed35b44.png)

![Screen Shot 2019-08-30 at 3 58 47 pm](https://user-images.githubusercontent.com/1097667/63996487-325f5f00-cb3f-11e9-85e9-96849f505392.png)
