### PR TITLE
Fix empty Repeater rows and default values

### DIFF
--- a/js/blocks/components/edit.js
+++ b/js/blocks/components/edit.js
@@ -7,7 +7,7 @@ const { Fragment } = wp.element;
 /**
  * Internal dependencies
  */
-import { AdvancedControls, BlockLabInspector, Fields, FormControls } from './';
+import { AdvancedControls, BlockLabInspector, FormControls } from './';
 import icons from '../../../assets/icons.json';
 
 /**

--- a/js/blocks/components/repeater-rows.js
+++ b/js/blocks/components/repeater-rows.js
@@ -129,26 +129,7 @@ import { Fields } from './';
 			 * Without this, it looks like setAttributes() doesn't recognize a change to the array, and the component doesn't re-render.
 			 */
 			const rows = repeaterRows.slice();
-
-			/*
-			 * Ensure that every row has the required attributes, so that we don't lose blank rows.
-			 */
-			for ( name in this.props.subFields ) {
-				rows.forEach( ( row ) => {
-					if ( ! row.hasOwnProperty( name ) ) {
-						row[ name ] = null;
-					}
-				} );
-			};
-
-			rows.splice(
-				to,
-				0,
-				rows.splice(
-					from,
-					1
-				)[0]
-			);
+			[ rows[ from ], rows[ to ] ] = [ rows[ to ], rows[ from ] ]
 
 			attr[ parentName ] = { rows };
 			parentBlockProps.setAttributes( attr );
@@ -177,20 +158,20 @@ import { Fields } from './';
 			<Fragment>
 				<div className="block-lab-repeater__rows" ref={ this.repeaterRows }>
 					{
-						rows && rows.map( ( row, rowIndex ) => {
+						rows.map( ( row, rowIndex ) => {
 							const activeClass = this.state.activeRow === parseInt( rowIndex ) ? 'active' : ''; // @todo: Make this dynamic.
 
 							return (
 								<BaseControl className={ `block-lab-repeater--row ${ activeClass }` } key={ `bl-row-${ rowIndex }` }>
 									<div className="block-lab-repeater--row-delete">
-									<IconButton
-										icon="no"
-										key={ `${ rowIndex }-menu` }
-										className="button-delete"
-										label={ __( 'Delete', 'block-lab' ) }
-										onClick={ this.removeRow( rowIndex ) }
-										isSmall
-									/>
+										<IconButton
+											icon="no"
+											key={ `${ rowIndex }-menu` }
+											className="button-delete"
+											label={ __( 'Delete', 'block-lab' ) }
+											onClick={ this.removeRow( rowIndex ) }
+											isSmall
+										/>
 									</div>
 									<Fields
 										fields={ subFields }

--- a/js/blocks/components/repeater-rows.js
+++ b/js/blocks/components/repeater-rows.js
@@ -175,7 +175,7 @@ import { Fields } from './';
 
 		return (
 			<Fragment>
-				<div className="block-lab-repeater__rows" ref={this.repeaterRows}>
+				<div className="block-lab-repeater__rows" ref={ this.repeaterRows }>
 					{
 						rows && rows.map( ( row, rowIndex ) => {
 							const activeClass = this.state.activeRow === parseInt( rowIndex ) ? 'active' : ''; // @todo: Make this dynamic.

--- a/js/blocks/controls/color.js
+++ b/js/blocks/controls/color.js
@@ -53,12 +53,12 @@ const BlockLabColorPopover = withState( {
 
 const BlockLabColorControl = ( props ) => {
 	const { field, getValue, onChange } = props;
-	const value = getValue( props );
+	const initialValue = getValue( props );
+	const value = 'undefined' !== typeof initialValue ? initialValue : field.default;
 
 	return (
 		<BaseControl label={ field.label } className="block-lab-color-control" help={ field.help }>
 			<TextControl
-				defaultValue={ field.default }
 				value={ value }
 				onChange={ onChange }
 			/>

--- a/js/blocks/controls/email.js
+++ b/js/blocks/controls/email.js
@@ -4,6 +4,8 @@ const { TextControl } = wp.components;
 
 const BlockLabEmailControl = ( props ) => {
 	const { field, getValue, onChange } = props;
+	const initialValue = getValue( props );
+	const value = 'undefined' !== typeof initialValue ? initialValue : field.default;
 
 	/**
 	 * Sets the Error Class for the Text Control.
@@ -24,8 +26,7 @@ const BlockLabEmailControl = ( props ) => {
 			label={ field.label }
 			placeholder={ field.placeholder || '' }
 			help={ field.help }
-			defaultValue={ field.default }
-			value={ getValue( props ) }
+			value={ value }
 			onChange={ onChange }
 			onFocus={ event => {
 				setErrorClass( document.activeElement, false );

--- a/js/blocks/controls/number.js
+++ b/js/blocks/controls/number.js
@@ -4,6 +4,8 @@ const { TextControl } = wp.components;
 
 const BlockLabNumberControl = ( props ) => {
 	const { field, getValue, onChange } = props;
+	const initialValue = getValue( props );
+	const value = 'undefined' !== typeof initialValue ? initialValue : field.default;
 
 	/**
 	 * Sets the Error Class for the Text Control.
@@ -24,8 +26,7 @@ const BlockLabNumberControl = ( props ) => {
 			label={ field.label }
 			placeholder={ field.placeholder || '' }
 			help={ field.help }
-			defaultValue={ field.default }
-			value={ getValue( props ) }
+			value={ value }
 			onChange={ ( numberControl ) => {
 				onChange( Number( numberControl ) );
 			} }

--- a/js/blocks/controls/repeater.js
+++ b/js/blocks/controls/repeater.js
@@ -10,13 +10,27 @@ const { BaseControl, IconButton } = wp.components;
 import { RepeaterRows } from '../components';
 
 const BlockLabRepeaterControl = ( props ) => {
-	const { field, getValue, onChange, parentBlock, parentBlockProps } = props;
+	const { field, onChange, parentBlock, parentBlockProps } = props;
 	const { attributes, setAttributes } = parentBlockProps;
 	const attr = { ...attributes };
 	const value = attr[ field.name ];
 	const defaultRows = [ {} ];
 	const hasRows = value && value.hasOwnProperty( 'rows' );
 	const rows = hasRows ? value.rows : defaultRows;
+
+	/**
+	 * Adds a new empty row, using { '': '' }.
+	 *
+	 * Simply using {} results in <ServerSideRender> not sending an empty row,
+	 * and the empty row isn't rendered in the editor.
+	 *
+	 * @see https://github.com/getblocklab/block-lab/issues/393
+	 */
+	const addEmptyRow = () => {
+		const withAddedRow = rows.concat( { '': '' } );
+		attr[ field.name ] = { rows: withAddedRow };
+		setAttributes( attr );
+	};
 
 	if ( ! hasRows ) {
 		onChange( { rows: defaultRows } );
@@ -35,11 +49,7 @@ const BlockLabRepeaterControl = ( props ) => {
 					icon="insert"
 					label={ __( 'Add new', 'block-lab' ) }
 					labelPosition="bottom"
-					onClick={ () => {
-						const withAddedRow = rows.concat( {} );
-						attr[ field.name ] = { rows: withAddedRow };
-						setAttributes( attr );
-					} }
+					onClick={ addEmptyRow }
 					disabled={ false }
 				/>
 			</div>

--- a/js/blocks/controls/text.js
+++ b/js/blocks/controls/text.js
@@ -2,6 +2,8 @@ const { TextControl } = wp.components;
 
 const BlockLabTextControl = ( props ) => {
 	const { field, getValue, onChange } = props;
+	const initialValue = getValue( props );
+	const value = 'undefined' !== typeof initialValue ? initialValue : field.default;
 
 	return (
 		<TextControl
@@ -9,8 +11,7 @@ const BlockLabTextControl = ( props ) => {
 			placeholder={ field.placeholder || '' }
 			maxLength={ field.maxlength }
 			help={ field.help }
-			defaultValue={ field.default }
-			value={ getValue( props ) }
+			value={ value }
 			onChange={ onChange }
 		/>
 	);

--- a/js/blocks/controls/url.js
+++ b/js/blocks/controls/url.js
@@ -4,6 +4,9 @@ const { TextControl } = wp.components;
 
 const BlockLabURLControl = ( props ) => {
 	const { field, getValue, onChange } = props;
+	const initialValue = getValue( props );
+	const value = 'undefined' !== typeof initialValue ? initialValue : field.default;
+
 
 	/**
 	 * Sets the Error Class for the Text Control.
@@ -24,8 +27,7 @@ const BlockLabURLControl = ( props ) => {
 			label={ field.label }
 			placeholder={ field.placeholder || '' }
 			help={ field.help }
-			defaultValue={ field.default }
-			value={ getValue( props ) }
+			value={ value }
 			onChange={ onChange }
 			onFocus={ event => {
 				setErrorClass( document.activeElement, false );

--- a/js/blocks/controls/url.js
+++ b/js/blocks/controls/url.js
@@ -7,7 +7,6 @@ const BlockLabURLControl = ( props ) => {
 	const initialValue = getValue( props );
 	const value = 'undefined' !== typeof initialValue ? initialValue : field.default;
 
-
 	/**
 	 * Sets the Error Class for the Text Control.
 	 *

--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -307,13 +307,19 @@ class Loader extends Component_Abstract {
 			// Similar to the logic above, populate the Repeater control's sub-fields with default values.
 			foreach ( $block->fields as $field ) {
 				if ( isset( $field->settings['sub_fields'] ) ) {
-					$existing_sub_fields           = isset( $attributes[ $field->name ]['rows'][0] ) ? $attributes[ $field->name ]['rows'][0] : array();
-					$missing_sub_schema_attributes = array_diff_key( $field->settings['sub_fields'], $existing_sub_fields );
-					foreach ( $missing_sub_schema_attributes as $sub_field_name => $sub_schema ) {
-						if ( isset( $sub_schema->settings['default'] ) ) {
-							$attributes[ $field->name ]['rows'][0][ $sub_field_name ] = $sub_schema->settings['default'];
+					$sub_field_settings = $field->settings['sub_fields'];
+					$rows               = $attributes[ $field->name ]['rows'];
+
+					// In each row, apply a field's default value if a value doesn't exist in the attributes.
+					foreach ( $rows as $row_index => $row ) {
+						foreach ( $sub_field_settings as $sub_field_name => $sub_field ) {
+							if ( ( ! isset( $row[ $sub_field_name ] ) ) && isset( $sub_field_settings[ $sub_field_name ]->settings['default'] ) ) {
+								$rows[ $row_index ][ $sub_field_name ] = $sub_field_settings[ $sub_field_name ]->settings['default'];
+							}
 						}
 					}
+
+					$attributes[ $field->name ]['rows'] = $rows;
 				}
 			}
 

--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -313,7 +313,7 @@ class Loader extends Component_Abstract {
 					// In each row, apply a field's default value if a value doesn't exist in the attributes.
 					foreach ( $rows as $row_index => $row ) {
 						foreach ( $sub_field_settings as $sub_field_name => $sub_field ) {
-							if ( ( ! isset( $row[ $sub_field_name ] ) ) && isset( $sub_field_settings[ $sub_field_name ]->settings['default'] ) ) {
+							if ( ! isset( $row[ $sub_field_name ] ) && isset( $sub_field_settings[ $sub_field_name ]->settings['default'] ) ) {
 								$rows[ $row_index ][ $sub_field_name ] = $sub_field_settings[ $sub_field_name ]->settings['default'];
 							}
 						}


### PR DESCRIPTION
# WIP

## Before
* On adding empty rows, they did not appear at all in the editor
* This looks to be from the way `<ServerSideRender>` [handles empty {}](https://github.com/WordPress/gutenberg/blob/e2490612decf2f0ac614d6ee9f6d1269d0bfc615/packages/server-side-render/src/server-side-render.js#L22)
* Default values were only applied to the first row

## After 
* This adds a workaround for that, setting the new row to `{ '': '' }`
* This still isn't ideal, and I should keep an eye out for a better approach
* Default values are now applied to all repeater rows, even for completely empty rows

Fixes #393