### PR TITLE
Add a function to reset rows, thanks to Ben's suggestion

### DIFF
--- a/php/helpers.php
+++ b/php/helpers.php
@@ -133,7 +133,7 @@ function block_rows( $name ) {
 }
 
 /**
- * Resets the repeater block rows at the end of the iteration.
+ * Resets the repeater block rows after the while loop.
  *
  * Similar to wp_reset_postdata().
  * Call this after the repeater loop's endwhile.

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -133,7 +133,16 @@ function block_rows( $name ) {
 }
 
 /**
- * Resets the block rows at the end of the iteration.
+ * Resets the repeater block rows at the end of the iteration.
+ *
+ * Similar to wp_reset_postdata().
+ * Call this after the repeater loop's endwhile.
+ * For example:
+ * while ( block_rows( 'example-repeater-name' ) ) :
+ *     block_row( 'example-repeater-name' );
+ *     block_sub_field( 'example-field' );
+ * endwhile;
+ * reset_block_rows( 'example-repeater-name' );
  *
  * @param string $name The name of the repeater field.
  */

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -135,9 +135,9 @@ function block_rows( $name ) {
 /**
  * Resets the repeater block rows after the while loop.
  *
- * Similar to wp_reset_postdata().
- * Call this after the repeater loop's endwhile.
+ * Similar to wp_reset_postdata(). Call this after the repeater loop.
  * For example:
+ *
  * while ( block_rows( 'example-repeater-name' ) ) :
  *     block_row( 'example-repeater-name' );
  *     block_sub_field( 'example-field' );

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -133,6 +133,15 @@ function block_rows( $name ) {
 }
 
 /**
+ * Resets the block rows at the end of the iteration.
+ *
+ * @param string $name The name of the repeater field.
+ */
+function reset_block_rows( $name ) {
+	block_lab()->loop()->reset( $name );
+}
+
+/**
  * Return the value of a sub-field.
  *
  * @param string $name The name of the sub-field.


### PR DESCRIPTION
# Before
When 2 of the same repeater blocks appeared on the same page, only the 1st appeared:
<img width="733" alt="repeater-here-now" src="https://user-images.githubusercontent.com/4063887/64200418-17982d80-ce52-11e9-9ffa-1c8ddd85d9f4.png">

# After
Both repeaters appear when calling the function `reset_block_rows()`:

<img width="807" alt="2nd-repeater-displays" src="https://user-images.githubusercontent.com/4063887/64203790-e15eac00-ce59-11e9-8037-19e4c2e0513b.png">


* As reported by Ben and Markus, it wasn't possible to have 2 of the same repeater block on a post.
* So this function simply calls: `block_lab()->loop()->reset( $name )`, on Ben's suggestion.
* It acts like [wp_reset_postdata()](https://developer.wordpress.org/reference/functions/wp_reset_postdata/), and should go at the end of the `if` block:

```php
$repeater_name = 'example-repeater-here';

if ( block_rows( $repeater_name ) ) :
	while ( block_rows( $repeater_name ) ) :
		block_row( $repeater_name );
			<?php block_sub_field( 'example-field-name' ); ?>
	endwhile;
	reset_block_rows( $repeater_name );
endif;

```

Fixes #410