### PR TITLE
Add a filter to allow getting more values from block_field()

### DIFF
--- a/php/helpers.php
+++ b/php/helpers.php
@@ -25,30 +25,27 @@ function block_field( $name, $echo = true ) {
 	 */
 	global $block_lab_attributes, $block_lab_config;
 
+	$default_fields = array( 'className' );
+
 	if ( ! isset( $block_lab_attributes ) || ! is_array( $block_lab_attributes ) ) {
 		return null;
 	}
 
-	$default_fields = array( 'className' );
+	$is_name_allowed = isset( $block_lab_config->fields[ $name ] ) || in_array( $name, $default_fields, true );
 
 	/**
-	 * Filters the default fields that are allowed in addition to the fields in block attributes.
+	 * Filters whether the $name argument to this function is allowed.
 	 *
-	 * Adding an attribute to this can enable outputting it via block_field().
-	 * Normally, this function only returns or echoes Block Lab attributes (fields), and one default field.
-	 * But this allows getting block attributes that might have been added by other plugins.
-	 * To allow getting another attribute, add it to the $default_fields array.
+	 * By default, this only allows a $name that is in the block fields or default fields, like 'className'.
+	 * Returning true to this filter can prevent exiting from block_field()
+	 * when looking for another value in the block attributes.
 	 *
-	 * @param string[] $default_fields Default block fields to allow.
-	 * @param string   $name The name of value to get.
+	 * @param bool   $is_name_allowed Whether the name is allowed.
+	 * @param string $name The name of value to get.
 	 */
-	$default_fields = apply_filters( 'block_lab_default_fields', $default_fields, $name );
+	$is_block_field_name_allowed = apply_filters( 'is_block_field_name_allowed', $is_name_allowed, $name );
 
-	if ( ! is_array( $default_fields ) ) {
-		return null;
-	}
-
-	if ( ! isset( $block_lab_config->fields[ $name ] ) && ! in_array( $name, $default_fields, true ) ) {
+	if ( ! $is_block_field_name_allowed ) {
 		return null;
 	}
 

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -25,27 +25,30 @@ function block_field( $name, $echo = true ) {
 	 */
 	global $block_lab_attributes, $block_lab_config;
 
-	$default_fields = array( 'className' );
-
 	if ( ! isset( $block_lab_attributes ) || ! is_array( $block_lab_attributes ) ) {
 		return null;
 	}
 
-	$is_name_allowed = isset( $block_lab_config->fields[ $name ] ) || in_array( $name, $default_fields, true );
+	$default_fields = array( 'className' );
 
 	/**
-	 * Filters whether the $name argument to this function is allowed.
+	 * Filters the default fields that are allowed in addition to the fields in block attributes.
 	 *
-	 * By default, this only allows a $name that is in the block fields or default fields, like 'className'.
-	 * Returning true to this filter can prevent exiting from block_field()
-	 * when looking for another value in the block attributes.
+	 * Adding an attribute to this can enable outputting it via block_field().
+	 * Normally, this function only returns or echoes Block Lab attributes (fields), and one default field.
+	 * But this allows getting block attributes that might have been added by other plugins.
+	 * To allow getting another attribute, add it to the $default_fields array.
 	 *
-	 * @param bool   $is_name_allowed Whether the name is allowed.
-	 * @param string $name The name of value to get.
+	 * @param string[] $default_fields Default block fields to allow.
+	 * @param string   $name The name of value to get.
 	 */
-	$is_block_field_name_allowed = apply_filters( 'is_block_field_name_allowed', $is_name_allowed, $name );
+	$default_fields = apply_filters( 'block_lab_default_fields', $default_fields, $name );
 
-	if ( ! $is_block_field_name_allowed ) {
+	if ( ! is_array( $default_fields ) ) {
+		return null;
+	}
+
+	if ( ! isset( $block_lab_config->fields[ $name ] ) && ! in_array( $name, $default_fields, true ) ) {
 		return null;
 	}
 

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -32,12 +32,13 @@ function block_field( $name, $echo = true ) {
 	$default_fields = array( 'className' => 'string' );
 
 	/**
-	 * Filters the default fields that are allowed in addition to the fields in block attributes.
+	 * Filters the default fields that are allowed in addition to Block Lab fields.
 	 *
 	 * Adding an attribute to this can enable outputting it via block_field().
 	 * Normally, this function only returns or echoes Block Lab attributes (fields), and one default field.
-	 * But this allows getting block attributes that might have been added by other plugins.
-	 * To allow getting another attribute, add it to the $default_fields array.
+	 * But this allows getting block attributes that might have been added by other plugins or JS.
+	 * To allow getting another attribute, add it to the $default_fields associative array.
+	 * For example, 'your-example-field' => 'array'.
 	 *
 	 * @param array  $default_fields An associative array of $field_name => $field_type.
 	 * @param string $name The name of value to get.

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -25,13 +25,27 @@ function block_field( $name, $echo = true ) {
 	 */
 	global $block_lab_attributes, $block_lab_config;
 
+	$default_fields = array( 'className' );
+
 	if ( ! isset( $block_lab_attributes ) || ! is_array( $block_lab_attributes ) ) {
 		return null;
 	}
 
-	$default_fields = array( 'className' );
+	$is_name_allowed = isset( $block_lab_config->fields[ $name ] ) || in_array( $name, $default_fields, true );
 
-	if ( ! isset( $block_lab_config->fields[ $name ] ) && ! in_array( $name, $default_fields, true ) ) {
+	/**
+	 * Filters whether the $name argument to this function is allowed.
+	 *
+	 * By default, this only allows a $name that is in the block fields or default fields, like 'className'.
+	 * Returning true to this filter can prevent exiting from block_field()
+	 * when looking for another value in the block attributes.
+	 *
+	 * @param bool   $is_name_allowed Whether the name is allowed.
+	 * @param string $name The name of value to get.
+	 */
+	$is_block_field_name_allowed = apply_filters( 'is_block_field_name_allowed', $is_name_allowed, $name );
+
+	if ( ! $is_block_field_name_allowed ) {
 		return null;
 	}
 

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -29,7 +29,7 @@ function block_field( $name, $echo = true ) {
 		return null;
 	}
 
-	$default_fields = array( 'className' );
+	$default_fields = array( 'className' => 'string' );
 
 	/**
 	 * Filters the default fields that are allowed in addition to the fields in block attributes.
@@ -39,16 +39,12 @@ function block_field( $name, $echo = true ) {
 	 * But this allows getting block attributes that might have been added by other plugins.
 	 * To allow getting another attribute, add it to the $default_fields array.
 	 *
-	 * @param string[] $default_fields Default block fields to allow.
-	 * @param string   $name The name of value to get.
+	 * @param array  $default_fields An associative array of $field_name => $field_type.
+	 * @param string $name The name of value to get.
 	 */
 	$default_fields = apply_filters( 'block_lab_default_fields', $default_fields, $name );
 
-	if ( ! is_array( $default_fields ) ) {
-		return null;
-	}
-
-	if ( ! isset( $block_lab_config->fields[ $name ] ) && ! in_array( $name, $default_fields, true ) ) {
+	if ( ! isset( $block_lab_config->fields[ $name ] ) && ! isset( $default_fields[ $name ] ) ) {
 		return null;
 	}
 
@@ -65,9 +61,10 @@ function block_field( $name, $echo = true ) {
 		$field   = $block_lab_config->fields[ $name ];
 		$value   = $field->cast_value( $value );
 		$control = $field->control;
-	} elseif ( in_array( $name, $default_fields, true ) ) {
-		// Cast default Editor attributes appropriately.
-		$value = strval( $value );
+	} elseif ( isset( $default_fields[ $name ] ) ) {
+		// Cast default Editor attributes and those added via a filter.
+		$field = new Blocks\Field( array( 'type' => $default_fields[ $name ] ) );
+		$value = $field->cast_value( $value );
 	}
 
 	/**

--- a/tests/php/unit/test-helpers.php
+++ b/tests/php/unit/test-helpers.php
@@ -92,6 +92,8 @@ class Test_Helpers extends \WP_UnitTestCase {
 		$this->assertEmpty( $echoed_value );
 
 		$default_fields_filter = 'block_lab_default_fields';
+
+		// Don't return anything from the filter callback, to test the behavior.
 		add_filter(
 			$default_fields_filter,
 			function( $default_fields ) use ( $additional_field_name ) {
@@ -120,7 +122,7 @@ class Test_Helpers extends \WP_UnitTestCase {
 		$return_value = block_field( $additional_field_name, true );
 		$echoed_value = ob_get_clean();
 
-		// Now that the filter returns true, the field should be echoed, even though it's not in $block_lab_config.
+		// Now that the filter includes the additional field, the field should be echoed, even though it's not in $block_lab_config.
 		$this->assertEquals( $additional_field_value, $return_value );
 		$this->assertEquals( $additional_field_value, $echoed_value );
 	}

--- a/tests/php/unit/test-helpers.php
+++ b/tests/php/unit/test-helpers.php
@@ -91,29 +91,7 @@ class Test_Helpers extends \WP_UnitTestCase {
 		$this->assertEmpty( $return_value );
 		$this->assertEmpty( $echoed_value );
 
-		add_filter(
-			'block_lab_default_fields',
-			function( $default_fields ) use ( $additional_field_name ) {
-				$default_fields[] = $additional_field_name;
-			}
-		);
-
-		ob_start();
-		$return_value = block_field( $additional_field_name, true );
-		$echoed_value = ob_get_clean();
-
-		// In case the filter accidentally doesn't return anything, there should still not be a fatal error, there should just be no output.
-		$this->assertEmpty( $return_value );
-		$this->assertEmpty( $echoed_value );
-		remove_all_filters( 'is_block_field_name_allowed' );
-
-		add_filter(
-			'block_lab_default_fields',
-			function( $default_fields ) use ( $additional_field_name ) {
-				$default_fields[] = $additional_field_name;
-				return $default_fields;
-			}
-		);
+		add_filter( 'is_block_field_name_allowed', '__return_true' );
 
 		ob_start();
 		$return_value = block_field( $additional_field_name, true );

--- a/tests/php/unit/test-helpers.php
+++ b/tests/php/unit/test-helpers.php
@@ -92,8 +92,6 @@ class Test_Helpers extends \WP_UnitTestCase {
 		$this->assertEmpty( $echoed_value );
 
 		$default_fields_filter = 'block_lab_default_fields';
-
-		// Don't return anything from the filter callback, to test the behavior.
 		add_filter(
 			$default_fields_filter,
 			function( $default_fields ) use ( $additional_field_name ) {
@@ -122,7 +120,7 @@ class Test_Helpers extends \WP_UnitTestCase {
 		$return_value = block_field( $additional_field_name, true );
 		$echoed_value = ob_get_clean();
 
-		// Now that the filter includes the additional field, the field should be echoed, even though it's not in $block_lab_config.
+		// Now that the filter returns true, the field should be echoed, even though it's not in $block_lab_config.
 		$this->assertEquals( $additional_field_value, $return_value );
 		$this->assertEquals( $additional_field_value, $echoed_value );
 	}

--- a/tests/php/unit/test-helpers.php
+++ b/tests/php/unit/test-helpers.php
@@ -18,7 +18,7 @@ class Test_Helpers extends \WP_UnitTestCase {
 	 * @inheritdoc
 	 */
 	public function tearDown() {
-		remove_all_filters( 'block_lab_default_fields' );
+		remove_all_filters( 'is_block_field_name_allowed' );
 		$GLOBALS['block_lab_attributes'] = array();
 		$GLOBALS['block_lab_config']     = array();
 		parent::tearDown();
@@ -91,9 +91,8 @@ class Test_Helpers extends \WP_UnitTestCase {
 		$this->assertEmpty( $return_value );
 		$this->assertEmpty( $echoed_value );
 
-		$default_fields_filter = 'block_lab_default_fields';
 		add_filter(
-			$default_fields_filter,
+			'block_lab_default_fields',
 			function( $default_fields ) use ( $additional_field_name ) {
 				$default_fields[] = $additional_field_name;
 			}
@@ -106,10 +105,10 @@ class Test_Helpers extends \WP_UnitTestCase {
 		// In case the filter accidentally doesn't return anything, there should still not be a fatal error, there should just be no output.
 		$this->assertEmpty( $return_value );
 		$this->assertEmpty( $echoed_value );
-		remove_all_filters( $default_fields_filter );
+		remove_all_filters( 'is_block_field_name_allowed' );
 
 		add_filter(
-			$default_fields_filter,
+			'block_lab_default_fields',
 			function( $default_fields ) use ( $additional_field_name ) {
 				$default_fields[] = $additional_field_name;
 				return $default_fields;

--- a/tests/php/unit/test-helpers.php
+++ b/tests/php/unit/test-helpers.php
@@ -18,7 +18,7 @@ class Test_Helpers extends \WP_UnitTestCase {
 	 * @inheritdoc
 	 */
 	public function tearDown() {
-		remove_all_filters( 'is_block_field_name_allowed' );
+		remove_all_filters( 'block_lab_default_fields' );
 		$GLOBALS['block_lab_attributes'] = array();
 		$GLOBALS['block_lab_config']     = array();
 		parent::tearDown();
@@ -91,8 +91,9 @@ class Test_Helpers extends \WP_UnitTestCase {
 		$this->assertEmpty( $return_value );
 		$this->assertEmpty( $echoed_value );
 
+		$default_fields_filter = 'block_lab_default_fields';
 		add_filter(
-			'block_lab_default_fields',
+			$default_fields_filter,
 			function( $default_fields ) use ( $additional_field_name ) {
 				$default_fields[] = $additional_field_name;
 			}
@@ -105,10 +106,10 @@ class Test_Helpers extends \WP_UnitTestCase {
 		// In case the filter accidentally doesn't return anything, there should still not be a fatal error, there should just be no output.
 		$this->assertEmpty( $return_value );
 		$this->assertEmpty( $echoed_value );
-		remove_all_filters( 'is_block_field_name_allowed' );
+		remove_all_filters( $default_fields_filter );
 
 		add_filter(
-			'block_lab_default_fields',
+			$default_fields_filter,
 			function( $default_fields ) use ( $additional_field_name ) {
 				$default_fields[] = $additional_field_name;
 				return $default_fields;

--- a/tests/php/unit/test-helpers.php
+++ b/tests/php/unit/test-helpers.php
@@ -113,7 +113,7 @@ class Test_Helpers extends \WP_UnitTestCase {
 		add_filter(
 			$default_fields_filter,
 			function( $default_fields ) use ( $additional_field_name ) {
-				$default_fields[] = $additional_field_name;
+				$default_fields[ $additional_field_name ] = 'string';
 				return $default_fields;
 			}
 		);

--- a/tests/php/unit/test-helpers.php
+++ b/tests/php/unit/test-helpers.php
@@ -91,7 +91,29 @@ class Test_Helpers extends \WP_UnitTestCase {
 		$this->assertEmpty( $return_value );
 		$this->assertEmpty( $echoed_value );
 
-		add_filter( 'is_block_field_name_allowed', '__return_true' );
+		add_filter(
+			'block_lab_default_fields',
+			function( $default_fields ) use ( $additional_field_name ) {
+				$default_fields[] = $additional_field_name;
+			}
+		);
+
+		ob_start();
+		$return_value = block_field( $additional_field_name, true );
+		$echoed_value = ob_get_clean();
+
+		// In case the filter accidentally doesn't return anything, there should still not be a fatal error, there should just be no output.
+		$this->assertEmpty( $return_value );
+		$this->assertEmpty( $echoed_value );
+		remove_all_filters( 'is_block_field_name_allowed' );
+
+		add_filter(
+			'block_lab_default_fields',
+			function( $default_fields ) use ( $additional_field_name ) {
+				$default_fields[] = $additional_field_name;
+				return $default_fields;
+			}
+		);
 
 		ob_start();
 		$return_value = block_field( $additional_field_name, true );

--- a/tests/php/unit/test-helpers.php
+++ b/tests/php/unit/test-helpers.php
@@ -13,19 +13,29 @@ use Block_Lab\Blocks;
 class Test_Helpers extends \WP_UnitTestCase {
 
 	/**
+	 * Teardown.
+	 *
+	 * @inheritdoc
+	 */
+	public function tearDown() {
+		remove_all_filters( 'is_block_field_name_allowed' );
+		$GLOBALS['block_lab_attributes'] = array();
+		$GLOBALS['block_lab_config']     = array();
+		parent::tearDown();
+	}
+
+	/**
 	 * Test block_field.
 	 *
 	 * @covers ::block_field()
 	 */
 	public function test_block_field() {
-		global $block_lab_attributes, $block_lab_config;
-
-		$field_name                          = 'test-user';
-		$class_key                           = 'className';
-		$expected_class                      = 'baz-class';
-		$mock_text                           = 'Example text';
-		$block_lab_attributes[ $field_name ] = $mock_text;
-		$block_lab_attributes[ $class_key ]  = $expected_class;
+		$field_name                                     = 'test-user';
+		$class_key                                      = 'className';
+		$expected_class                                 = 'baz-class';
+		$mock_text                                      = 'Example text';
+		$GLOBALS['block_lab_attributes'][ $field_name ] = $mock_text;
+		$GLOBALS['block_lab_attributes'][ $class_key ]  = $expected_class;
 
 		$field_config = array( 'control' => 'text' );
 		$block_config = array(
@@ -34,8 +44,8 @@ class Test_Helpers extends \WP_UnitTestCase {
 			),
 		);
 
-		$block_lab_config = new Blocks\Block();
-		$block_lab_config->from_array( $block_config );
+		$GLOBALS['block_lab_config'] = new Blocks\Block();
+		$GLOBALS['block_lab_config']->from_array( $block_config );
 
 		// Because block_field() had the second argument of false, this should return the value stored in the field, not echo it.
 		ob_start();
@@ -66,5 +76,29 @@ class Test_Helpers extends \WP_UnitTestCase {
 		// Test the same scenario as above, but for 'className'.
 		$this->assertEquals( $expected_class, $actual_class );
 		$this->assertEquals( $return_value, $actual_class );
+
+		$additional_field_name           = 'example_additional_field';
+		$additional_field_value          = 'Here is some text';
+		$GLOBALS['block_lab_attributes'] = array(
+			$additional_field_name => $additional_field_value,
+		);
+
+		ob_start();
+		$return_value = block_field( $additional_field_name, true );
+		$echoed_value = ob_get_clean();
+
+		// When a field isn't in the $block_lab_config, it should not be echoed or returned.
+		$this->assertEmpty( $return_value );
+		$this->assertEmpty( $echoed_value );
+
+		add_filter( 'is_block_field_name_allowed', '__return_true' );
+
+		ob_start();
+		$return_value = block_field( $additional_field_name, true );
+		$echoed_value = ob_get_clean();
+
+		// Now that the filter returns true, the field should be echoed, even though it's not in $block_lab_config.
+		$this->assertEquals( $additional_field_value, $return_value );
+		$this->assertEquals( $additional_field_value, $echoed_value );
 	}
 }


### PR DESCRIPTION
* An alternative to #373 
* This will make it possible for `block_field()` to return or echo additional block attributes that another plugin might have added, like in this [example usage](https://github.com/phpbits/block-options/blob/57a752f703590ea719bb9c85fad1f3a0e97b1fa0/includes/helper.php#L10-L17) of this filter. 
* It's possible to add block attributes [by filtering](https://github.com/phpbits/block-options/blob/9c6aadfc8d7a5153d17acb0bb3630296cfa21c8b/src/extensions/attributes/index.js#L28) the JavaScript function `registerBlockType()`. For example, Editorskit [adds an editorskit object](https://github.com/phpbits/block-options/blob/9c6aadfc8d7a5153d17acb0bb3630296cfa21c8b/src/extensions/attributes/index.js#L28-L43) to the block attributes, and uses it [in the Inspector Controls](https://github.com/phpbits/block-options/blob/aad4e9aa0f49ba29d226ecbf7357f60e7863ed3a/src/extensions/advanced-controls/index.js#L101).
* But before, it wasn't possible to output these attributes with `block_field()`. That only allowed registered Block Lab fields and `className`. 
