### PR TITLE
Fix an issue with the Textarea in the Repeater

### DIFF
--- a/js/blocks/controls/textarea.js
+++ b/js/blocks/controls/textarea.js
@@ -2,6 +2,8 @@ const { TextareaControl } = wp.components;
 
 const BlockLabTextareaControl = ( props ) => {
 	const { getValue, field, onChange } = props
+	const initialValue = getValue( props );
+	const value = 'undefined' !== typeof initialValue ? initialValue : field.default;
 
 	return (
 		<TextareaControl
@@ -10,8 +12,7 @@ const BlockLabTextareaControl = ( props ) => {
 			maxLength={ field.maxlength }
 			rows={ field.number_rows }
 			help={ field.help }
-			defaultValue={ field.default }
-			value={ getValue( props ) }
+			value={ value }
 			onChange={ onChange }
 		/>
 	);


### PR DESCRIPTION
# Before
Like the issue we saw in #409, if a Repeater has a Textarea with a value, and it's moved, it can replace the value of a blank Textarea:

![mo-repeater](https://user-images.githubusercontent.com/4063887/64220158-f0f7e800-ce8d-11e9-81cc-efc297728916.gif)


# After 
The empty Textarea remains empty, as expected