### PR TITLE
Fix a license validation issue for 'lifetime'

### DIFF
--- a/php/admin/class-license.php
+++ b/php/admin/class-license.php
@@ -95,7 +95,15 @@ class License extends Component_Abstract {
 		$license = $this->get_license();
 
 		if ( isset( $license['license'] ) && 'valid' === $license['license'] ) {
-			if ( isset( $license['expires'] ) && time() < strtotime( $license['expires'] ) ) {
+			if (
+				isset( $license['expires'] )
+				&&
+				(
+					'lifetime' === $license['expires']
+					||
+					time() < strtotime( $license['expires'] )
+				)
+			) {
 				return true;
 			}
 		}


### PR DESCRIPTION
# WIP

* Account for 'lifetime' license values
* Instead of an 'expires' time, it looks like the EDD API sometimes returns 'lifetime' for that type of license.