### PR TITLE
Add the validation filter to block_sub_field()

### DIFF
--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -72,6 +72,7 @@ class Block_Post extends Component_Abstract {
 		add_action( 'wp_insert_post_data', array( $this, 'save_block' ), 10, 2 );
 		add_action( 'init', array( $this, 'register_controls' ) );
 		add_filter( 'block_lab_field_value', array( $this, 'get_field_value' ), 10, 3 );
+		add_filter( 'block_lab_sub_field_value', array( $this, 'get_field_value' ), 10, 3 );
 
 		// Clean up the list table.
 		add_filter( 'disable_months_dropdown', '__return_true', 10, $this->slug );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,7 @@
 		</testsuite>
 
 		<testsuite name="integration">
+			<directory suffix=".php">./tests/php/integration/helpers/</directory>
 			<directory prefix="test-" suffix=".php">./tests/php/integration/</directory>
 		</testsuite>
 	</testsuites>

--- a/tests/php/integration/fixtures/all-fields-except-repeater.php
+++ b/tests/php/integration/fixtures/all-fields-except-repeater.php
@@ -38,7 +38,7 @@ foreach ( $non_object_fields as $field ) :
 	<p>
 		<?php
 		printf(
-			'And here is the result of calling block_value() for %s: %s',
+			'Here is the result of calling block_value() for %s: %s',
 			$field,
 			block_value( $field )
 		);
@@ -62,11 +62,18 @@ foreach ( $non_string_fields as $name => $value ) :
 
 	$block_value = block_value( $name );
 	foreach ( $value as $block_value_property ) :
-		printf(
-			'Here is the result of passing %s to block_value() with the property %s: %s',
-			$name,
-			$block_value_property,
-			$block_value->$block_value_property
-		);
+		if ( isset( $block_value->$block_value_property ) ) :
+			printf(
+				'Here is the result of passing %s to block_value() with the property %s: %s',
+				$name,
+				$block_value_property,
+				$block_value->$block_value_property
+			);
+		endif;
 	endforeach;
 endforeach;
+
+printf(
+	'Here is the result of block_field() for multiselect: %s',
+	block_field( 'multiselect' )
+);

--- a/tests/php/integration/fixtures/all-fields-except-repeater.php
+++ b/tests/php/integration/fixtures/all-fields-except-repeater.php
@@ -27,7 +27,6 @@ foreach ( $non_object_fields as $field ) :
 	?>
 	<p class="<?php block_field( 'className' ); ?>">
 		<?php
-		/* translators: %s is the field name */
 		printf(
 			'Here is the result of block_field() for %s: ',
 			$field
@@ -38,7 +37,6 @@ foreach ( $non_object_fields as $field ) :
 
 	<p>
 		<?php
-		/* translators: %s is the field name, %s is the result of calling block_value() */
 		printf(
 			'And here is the result of calling block_value() for %s: %s',
 			$field,
@@ -56,7 +54,6 @@ $non_string_fields = array(
 );
 
 foreach ( $non_string_fields as $name => $value ) :
-	/* translators: %s is the field name */
 	printf(
 		'Here is the result of block_field() for %s: ',
 		$name

--- a/tests/php/integration/fixtures/repeater-all-fields.php
+++ b/tests/php/integration/fixtures/repeater-all-fields.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * A mock template for a block, testing a repeater with all field types as sub_fields.
+ *
+ * @package Block_Lab
+ */
+
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaping could interfere with testing block_sub_value().
+
+$repeater_name     = 'repeater';
+$non_object_fields = array(
+	'text',
+	'textarea',
+	'url',
+	'email',
+	'number',
+	'color',
+	'image',
+	'select',
+	'toggle',
+	'range',
+	'checkbox',
+	'radio',
+	'rich-text',
+);
+
+?>
+<div class="<?php block_field( 'className' ); ?>">
+<?php
+if ( block_rows( $repeater_name ) ) :
+	$row_number = 0;
+	while ( block_rows( $repeater_name ) ) :
+		block_row( $repeater_name );
+
+		foreach ( $non_object_fields as $field ) :
+			?>
+			<p class="<?php block_field( 'className' ); ?>">
+				<?php
+				printf(
+					'In row %d, here is the result of block_sub_field() for %s: ',
+					$row_number,
+					$field
+				);
+				block_sub_field( $field );
+				?>
+			</p>
+
+			<p>
+				<?php
+				printf(
+					'And in row %d, here is the result of calling block_sub_value() for %s: %s',
+					$row_number,
+					$field,
+					block_sub_value( $field )
+				);
+				?>
+			</p>
+			<?php
+		endforeach;
+
+		$non_string_fields = array(
+			'post'     => array( 'ID', 'post_name' ),
+			'taxonomy' => array( 'term_id', 'name' ),
+			'user'     => array( 'ID', 'first_name' ),
+		);
+
+		foreach ( $non_string_fields as $name => $value ) :
+			printf(
+				'In row %d, here is the result of block_sub_field() for %s: ',
+				$row_number,
+				$name
+			);
+			block_sub_field( $name );
+
+			$block_sub_value = block_sub_value( $name );
+			foreach ( $value as $block_value_property ) :
+				printf(
+					'In row %d, here is the result of passing %s to block_sub_value() with the property %s: %s',
+					$row_number,
+					$name,
+					$block_value_property,
+					$block_sub_value->$block_value_property
+				);
+			endforeach;
+		endforeach;
+
+		$row_number++;
+	endwhile;
+	reset_block_rows( $repeater_name );
+endif;

--- a/tests/php/integration/helpers/class-abstract-attribute.php
+++ b/tests/php/integration/helpers/class-abstract-attribute.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Abstract_Attribute
+ *
+ * @package Block_Lab
+ */
+
+/**
+ * Class Abstract_Attribute
+ *
+ * @package Block_Lab
+ */
+abstract class Abstract_Attribute extends \WP_UnitTestCase {
+
+	/**
+	 * The block attributes.
+	 *
+	 * @var array
+	 */
+	public $attributes;
+
+	/**
+	 * All fields that return a string for block_value().
+	 *
+	 * @var array
+	 */
+	public $string_fields;
+
+	/**
+	 * All fields that return either an object or ID for block_value().
+	 *
+	 * @var array
+	 */
+	public $object_fields;
+
+	/**
+	 * The instance of Loader, to render the template.
+	 *
+	 * @var Blocks\Loader
+	 */
+	public $loader;
+
+	/**
+	 * The name of the block that tests all fields.
+	 *
+	 * This also controls the template that will be used.
+	 * For example, if $block_name is 'your-example-block',
+	 * the template will be at fixtures/your-example-block.php.
+	 *
+	 * @var string
+	 */
+	public $block_name;
+
+	/**
+	 * The name of the block with the prefix.
+	 *
+	 * @var string
+	 */
+	public $prefixed_block_name;
+
+	/**
+	 * The path to the blocks/ directory in the theme.
+	 *
+	 * @var string
+	 */
+	public $blocks_directory;
+
+	/**
+	 * The location of the block template.
+	 *
+	 * @var string
+	 */
+	public $template_location;
+
+	/**
+	 * The block class name.
+	 *
+	 * @var string
+	 */
+	public $class_name = 'example-name';
+
+	/**
+	 * The names of the fields that don't fall into the string or object field classifications.
+	 *
+	 * @var string[]
+	 */
+	public $special_case_field_names = array(
+		'checkbox',
+		'image',
+		'rich-text',
+		'toggle',
+	);
+
+	/**
+	 * Setup.
+	 *
+	 * @inheritdoc
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->set_properties();
+		$this->create_block_template();
+	}
+
+	/**
+	 * Teardown.
+	 *
+	 * @inheritdoc
+	 */
+	public function tearDown() {
+		parent::setUp();
+
+		if ( file_exists( $this->template_location ) ) {
+			unlink( $this->template_location );
+		}
+		if ( is_dir( $this->blocks_directory ) ) {
+			rmdir( $this->blocks_directory );
+		}
+	}
+
+	/**
+	 * Sets class properties.
+	 */
+	public function set_properties() {}
+
+	/**
+	 * Creates the block template.
+	 *
+	 * Instead of copying the fixture entirely into the theme directory,
+	 * this puts an include statement in it, pointing to the fixture.
+	 */
+	public function create_block_template() {
+		$this->prefixed_block_name = "block-lab/{$this->block_name}";
+		$theme_directory           = get_template_directory();
+		$template_path_in_fixtures = dirname( __DIR__ ) . "/fixtures/{$this->block_name}.php";
+		$this->blocks_directory    = "{$theme_directory}/blocks";
+		$this->template_location   = "{$this->blocks_directory}/block-{$this->block_name}.php";
+
+		if ( ! is_dir( $this->blocks_directory ) ) {
+			mkdir( $this->blocks_directory );
+		}
+		$template_contents = sprintf( "<?php include '%s';", $template_path_in_fixtures );
+		file_put_contents( $this->template_location, $template_contents ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
+	}
+
+	/**
+	 * Gets the post attributes.
+	 *
+	 * @return array
+	 */
+	public function get_post_attributes() {
+		$id = $this->factory()->post->create();
+
+		return array(
+			'id'   => $id,
+			'name' => get_the_title( $id ),
+		);
+	}
+
+	/**
+	 * Gets the taxonomy attributes.
+	 *
+	 * @return array
+	 */
+	public function get_taxonomy_attributes() {
+		$term = $this->factory()->tag->create_and_get();
+
+		return array(
+			'id'   => $term->term_id,
+			'name' => $term->name,
+		);
+	}
+
+	/**
+	 * Gets the user attributes.
+	 *
+	 * @return array
+	 */
+	public function get_user_attributes() {
+		$user = $this->factory()->user->create_and_get();
+
+		return array(
+			'id'       => $user->ID,
+			'userName' => $user->display_name,
+		);
+	}
+
+	/**
+	 * Gets the image attribute.
+	 *
+	 * @return int The image's ID.
+	 */
+	public function get_image_attribute() {
+		return $this->factory()->attachment->create_object(
+			array( 'file' => 'baz.jpeg' ),
+			0,
+			array( 'post_mime_type' => 'image/jpeg' )
+		);
+	}
+}

--- a/tests/php/integration/test-defaults.php
+++ b/tests/php/integration/test-defaults.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Test_Defaults
+ *
+ * @package Block_Lab
+ */
+
+use Block_Lab\Blocks;
+use Block_Lab\Post_Types;
+
+/**
+ * Class Test_Defaults
+ *
+ * @package Block_Lab
+ */
+class Test_Defaults extends Abstract_Attribute {
+
+	/**
+	 * Field defaults.
+	 *
+	 * An associative array of $field_name => $default_value.
+	 *
+	 * @var array
+	 */
+	public $defaults;
+
+	/**
+	 * Fields that don't fit well into the other test groups.
+	 *
+	 * @var array
+	 */
+	public $special_case_fields;
+
+	/**
+	 * Sets class properties.
+	 */
+	public function set_properties() {
+		$this->block_name = 'all-fields-except-repeater';
+		$this->loader     = new Blocks\Loader();
+
+		$this->attributes = array(
+			'className' => $this->class_name,
+		);
+
+		$this->defaults = array(
+			'checkbox'    => 1,
+			'color'       => '#777777',
+			'email'       => 'yourname@example.com',
+			'multiselect' => array( 'example-default' ),
+			'number'      => '56',
+			'radio'       => 'baz',
+			'range'       => 5,
+			'rich-text'   => 'Here is the Rich Text default value',
+			'select'      => 'another',
+			'text'        => 'This is the text default value',
+			'textarea'    => 'And this is the Textarea default',
+			'toggle'      => 1,
+			'url'         => 'https://example.com/this-is-a-default',
+		);
+
+		$this->string_fields = array(
+			'color',
+			'email',
+			'number',
+			'radio',
+			'range',
+			'select',
+			'text',
+			'textarea',
+			'url',
+		);
+
+		$rich_text_value           = sprintf( '<p>%s</p></p>', $this->defaults['rich-text'] );
+		$this->special_case_fields = array(
+			'checkbox'    => array(
+				'block_field' => $this->defaults['checkbox'] ? 'Yes' : 'No',
+				'block_value' => $this->defaults['checkbox'] ? '1' : '',
+			),
+			'multiselect' => array(
+				'block_field' => 'example-default',
+			),
+			'rich-text'   => array(
+				'block_field' => $rich_text_value,
+				'block_value' => $rich_text_value,
+			),
+			'toggle'      => array(
+				'block_field' => $this->defaults['toggle'] ? 'Yes' : 'No',
+				'block_value' => $this->defaults['toggle'] ? '1' : '',
+			),
+		);
+	}
+
+	/**
+	 * Gets the block config.
+	 *
+	 * @return array The config for the block.
+	 */
+	public function get_block_config() {
+		$block_post = new Post_Types\Block_Post();
+		$fields     = array();
+
+		foreach ( $this->defaults as $field_name => $default_value ) {
+			$control_name          = str_replace( '-', '_', $field_name );
+			$control               = $block_post->get_control( $control_name );
+			$fields[ $field_name ] = array(
+				'control'  => str_replace( '-', '_', $field_name ),
+				'name'     => $control_name,
+				'type'     => $control->type,
+				'settings' => array(
+					'default' => $this->defaults[ $field_name ],
+				),
+			);
+		}
+
+		return array(
+			'category' => array(
+				'icon'  => null,
+				'slug'  => '',
+				'title' => '',
+			),
+			'excluded' => array(),
+			'fields'   => $fields,
+			'icon'     => 'block_lab',
+			'keywords' => array( '' ),
+			'name'     => $this->block_name,
+			'title'    => 'All Fields',
+		);
+	}
+
+	/**
+	 * Tests whether the rendered block template has the default values.
+	 *
+	 * Every field that has a possible default value is tested.
+	 * This loads the mock template in the theme's blocks/ directory,
+	 * and ensures that all of these fields appear correctly in it.
+	 */
+	public function test_block_template() {
+		$block = new Blocks\Block();
+		$block->from_array( $this->get_block_config() );
+		$rendered_template = $this->loader->render_block_template( $block, $this->attributes );
+		$actual_template   = str_replace( array( "\t", "\n" ), '', $rendered_template );
+
+		// The 'className' should be present.
+		$this->assertContains(
+			sprintf( '<p class="%s">', $this->class_name ),
+			$actual_template
+		);
+
+		// Test the fields that return a string for block_value().
+		foreach ( $this->string_fields as $field_name ) {
+			$this->assertContains(
+				sprintf(
+					'Here is the result of calling block_value() for %s: %s',
+					$field_name,
+					$this->defaults[ $field_name ]
+				),
+				$actual_template
+			);
+
+			$this->assertContains(
+				sprintf(
+					'Here is the result of block_field() for %s: %s',
+					$field_name,
+					$this->defaults[ $field_name ]
+				),
+				$actual_template
+			);
+		}
+
+		// Test the fields that don't have simple string results for block_field() and block_value().
+		foreach ( $this->special_case_fields as $field_name => $expected_values ) {
+			$this->assertContains(
+				sprintf(
+					'Here is the result of block_field() for %s: %s',
+					$field_name,
+					$expected_values['block_field']
+				),
+				$actual_template
+			);
+
+			if ( isset( $expected_values['block_value'] ) ) {
+				$this->assertContains(
+					sprintf(
+						'Here is the result of calling block_value() for %s: %s',
+						$field_name,
+						$expected_values['block_value']
+					),
+					$actual_template
+				);
+			}
+		}
+	}
+}

--- a/tests/php/integration/test-repeater-template-output.php
+++ b/tests/php/integration/test-repeater-template-output.php
@@ -16,7 +16,7 @@ use Block_Lab\Post_Types;
 class Test_Repeater_Template_Output extends Abstract_Attribute {
 
 	/**
-	 * The field nam e of the repeater.
+	 * The field name of the repeater.
 	 *
 	 * @var string
 	 */
@@ -169,9 +169,9 @@ class Test_Repeater_Template_Output extends Abstract_Attribute {
 			'excluded' => array(),
 			'fields'   => $fields,
 			'icon'     => 'block_lab',
-			'keywords' => array( '' ),
+			'keywords' => array( 'Repeater' ),
 			'name'     => $this->block_name,
-			'title'    => 'All Fields',
+			'title'    => 'Repeater With All Fields',
 		);
 	}
 
@@ -200,7 +200,7 @@ class Test_Repeater_Template_Output extends Abstract_Attribute {
 			foreach ( $this->string_fields as $field ) {
 				$this->assertContains(
 					sprintf(
-						esc_html( 'And in row %d, here is the result of calling block_sub_value() for %s: %s', 'bl-testing-templates' ),
+						'And in row %d, here is the result of calling block_sub_value() for %s: %s',
 						$row_number,
 						$field,
 						$row[ $field ]
@@ -210,7 +210,7 @@ class Test_Repeater_Template_Output extends Abstract_Attribute {
 
 				$this->assertContains(
 					sprintf(
-						esc_html( 'In row %d, here is the result of block_sub_field() for %s: %s', 'bl-testing-templates' ),
+						'In row %d, here is the result of block_sub_field() for %s: %s',
 						$row_number,
 						$field,
 						$row[ $field ]

--- a/tests/php/integration/test-repeater-template-output.php
+++ b/tests/php/integration/test-repeater-template-output.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * Test_Repeater_Template_Output
+ *
+ * @package Block_Lab
+ */
+
+use Block_Lab\Blocks;
+use Block_Lab\Post_Types;
+
+/**
+ * Class Test_Repeater_Template_Output
+ *
+ * @package Block_Lab
+ */
+class Test_Repeater_Template_Output extends Abstract_Attribute {
+
+	/**
+	 * The field nam e of the repeater.
+	 *
+	 * @var string
+	 */
+	const REPEATER_FIELD_NAME = 'repeater';
+
+	/**
+	 * Fields that don't fit well into the other test groups.
+	 *
+	 * @var array[]
+	 */
+	public $special_case_fields = array();
+
+	/**
+	 * Sets class properties.
+	 */
+	public function set_properties() {
+		$this->block_name = 'repeater-all-fields';
+		$this->loader     = new Blocks\Loader();
+
+		$this->attributes = array(
+			'className'               => $this->class_name,
+			self::REPEATER_FIELD_NAME => array(
+				'rows' => array(
+					array(
+						'checkbox'    => true,
+						'text'        => 'Here is a text field',
+						'textarea'    => 'This is the first lineAnd here is another',
+						'url'         => 'https://example/an-example-url',
+						'email'       => 'bravo@emal.com',
+						'number'      => 51315,
+						'color'       => 'rgba(68, 34, 65, 0.26666666666666666)',
+						'image'       => $this->get_image_attribute(),
+						'select'      => 'bar',
+						'multiselect' => array( 'bar' ),
+						'toggle'      => true,
+						'range'       => 6,
+						'radio'       => 'bar',
+						'post'        => $this->get_post_attributes(),
+						'rich-text'   => '<p>This is <strong>bold</strong></p><p>And this is <em>italic</em></p>',
+						'taxonomy'    => $this->get_taxonomy_attributes(),
+						'user'        => $this->get_user_attributes(),
+					),
+					array(
+						''            => '',
+						'checkbox'    => false,
+						'text'        => 'This is the second row',
+						'textarea'    => 'Here is the textarea of the second rowAnd another line',
+						'url'         => 'https://example.com/example-url-here',
+						'email'       => 'yours@example.com',
+						'number'      => 14,
+						'color'       => 'rgba(53, 158, 53, 0.26666666666666666)',
+						'image'       => $this->get_image_attribute(),
+						'select'      => 'foo',
+						'multiselect' => array( 'bar' ),
+						'toggle'      => false,
+						'range'       => 9,
+						'radio'       => 'bar',
+						'post'        => $this->get_post_attributes(),
+						'rich-text'   => '<p>This is the first line</p><p>Here is <em>italic</em> and here is <strong>bold</strong></p>',
+						'taxonomy'    => $this->get_taxonomy_attributes(),
+						'user'        => $this->get_user_attributes(),
+					),
+				),
+			),
+		);
+
+		$this->string_fields = array(
+			'text',
+			'textarea',
+			'url',
+			'email',
+			'number',
+			'color',
+			'select',
+			'range',
+			'radio',
+		);
+
+		$this->object_fields = array(
+			'multiselect',
+			'post',
+			'taxonomy',
+			'user',
+		);
+
+		foreach ( $this->attributes[ self::REPEATER_FIELD_NAME ]['rows'] as $row ) {
+			$image = wp_get_attachment_image_src( $row['image'], 'full' );
+
+			$this->special_case_fields[] = array(
+				'checkbox'  => array(
+					'block_sub_field' => $row['checkbox'] ? 'Yes' : 'No',
+					'block_sub_value' => $row['checkbox'] ? '1' : '',
+				),
+				'image'     => array(
+					'block_sub_field' => $image[0],
+					'block_sub_value' => $row['image'],
+				),
+				'rich-text' => array(
+					'block_sub_field' => $row['rich-text'],
+					'block_sub_value' => $row['rich-text'],
+				),
+				'toggle'    => array(
+					'block_sub_field' => $row['toggle'] ? 'Yes' : 'No',
+					'block_sub_value' => $row['toggle'] ? '1' : '',
+				),
+			);
+		}
+	}
+
+	/**
+	 * Gets the block config.
+	 *
+	 * @return array The config for the block.
+	 */
+	public function get_block_config() {
+		$block_post = new Post_Types\Block_Post();
+		$all_fields = array_merge(
+			$this->string_fields,
+			$this->object_fields,
+			$this->special_case_field_names
+		);
+
+		$sub_fields = array();
+		foreach ( $all_fields as $field_name ) {
+			$control_name              = str_replace( '-', '_', $field_name );
+			$control                   = $block_post->get_control( $control_name );
+			$sub_fields[ $field_name ] = array(
+				'control' => str_replace( '-', '_', $field_name ),
+				'name'    => $control_name,
+				'type'    => $control->type,
+				'parent'  => self::REPEATER_FIELD_NAME,
+			);
+		}
+
+		$fields = array(
+			self::REPEATER_FIELD_NAME => array(
+				'control'    => 'repeater',
+				'name'       => 'repeater',
+				'type'       => 'object',
+				'sub_fields' => $sub_fields,
+			),
+		);
+
+		return array(
+			'category' => array(
+				'icon'  => null,
+				'slug'  => '',
+				'title' => '',
+			),
+			'excluded' => array(),
+			'fields'   => $fields,
+			'icon'     => 'block_lab',
+			'keywords' => array( '' ),
+			'name'     => $this->block_name,
+			'title'    => 'All Fields',
+		);
+	}
+
+	/**
+	 * Tests whether the repeater template has the expected values.
+	 *
+	 * This has a repeater with 2 rows, and tests every possible field.
+	 * It sets mock block attributes, like those that would be saved from a block.
+	 * Then, it loads the mock template in the theme's blocks/ directory and asserts the values.
+	 */
+	public function test_repeater_template() {
+		$block = new Blocks\Block();
+		$block->from_array( $this->get_block_config() );
+		$rendered_template = $this->loader->render_block_template( $block, $this->attributes );
+		$actual_template   = str_replace( array( "\t", "\n" ), '', $rendered_template );
+		$rows              = $this->attributes[ self::REPEATER_FIELD_NAME ]['rows'];
+
+		// The 'className' should be present.
+		$this->assertContains(
+			sprintf( '<div class="%s">', $this->class_name ),
+			$actual_template
+		);
+
+		// Test the fields that return a string for block_sub_value().
+		foreach ( $rows as $row_number => $row ) {
+			foreach ( $this->string_fields as $field ) {
+				$this->assertContains(
+					sprintf(
+						esc_html( 'And in row %d, here is the result of calling block_sub_value() for %s: %s', 'bl-testing-templates' ),
+						$row_number,
+						$field,
+						$row[ $field ]
+					),
+					$actual_template
+				);
+
+				$this->assertContains(
+					sprintf(
+						esc_html( 'In row %d, here is the result of block_sub_field() for %s: %s', 'bl-testing-templates' ),
+						$row_number,
+						$field,
+						$row[ $field ]
+					),
+					$actual_template
+				);
+			}
+		}
+
+		$object_fields = array();
+
+		foreach ( $rows as $row ) {
+			$object_fields[] = array(
+				'post'     => array(
+					'object'     => get_post( $row['post']['id'] ),
+					'properties' => array( 'ID', 'post_name' ),
+				),
+				'taxonomy' => array(
+					'object'     => get_term( $row['taxonomy']['id'] ),
+					'properties' => array( 'term_id', 'name' ),
+				),
+				'user'     => array(
+					'object'     => get_user_by( 'id', $row['user']['id'] ),
+					'properties' => array( 'ID', 'first_name' ),
+				),
+			);
+		}
+
+		/*
+		 * The fields here return objects for block_sub_value(), so test that some of the properties are correct.
+		 * For example, block_sub_value( 'post' )->ID.
+		 */
+		foreach ( $object_fields as $row_number => $fields ) {
+			foreach ( $fields as $name => $field ) {
+				foreach ( $field['properties'] as $property ) {
+					$this->assertContains(
+						sprintf(
+							'In row %d, here is the result of passing %s to block_sub_value() with the property %s: %s',
+							$row_number,
+							$name,
+							$property,
+							$field['object']->$property
+						),
+						$actual_template
+					);
+				}
+			}
+		}
+
+		// Test the fields that don't fit well into the tests above.
+		foreach ( $this->special_case_fields as $row_number => $special_case_field_row ) {
+			foreach ( $special_case_field_row as $field_name => $expected ) {
+				$this->assertContains(
+					sprintf(
+						'In row %d, here is the result of block_sub_field() for %s: %s',
+						$row_number,
+						$field_name,
+						$expected['block_sub_field']
+					),
+					$actual_template
+				);
+
+				$this->assertContains(
+					sprintf(
+						'And in row %d, here is the result of calling block_sub_value() for %s: %s',
+						$row_number,
+						$field_name,
+						$expected['block_sub_value']
+					),
+					$actual_template
+				);
+			}
+		}
+	}
+}

--- a/tests/php/integration/test-template-output.php
+++ b/tests/php/integration/test-template-output.php
@@ -156,7 +156,7 @@ class Test_Template_Output extends Abstract_Attribute {
 		foreach ( $this->string_fields as $field ) {
 			$this->assertContains(
 				sprintf(
-					'And here is the result of calling block_value() for %s: %s',
+					'Here is the result of calling block_value() for %s: %s',
 					$field,
 					$this->attributes[ $field ]
 				),
@@ -219,7 +219,7 @@ class Test_Template_Output extends Abstract_Attribute {
 
 			$this->assertContains(
 				sprintf(
-					'And here is the result of calling block_value() for %s: %s',
+					'Here is the result of calling block_value() for %s: %s',
 					$field_name,
 					$expected['block_value']
 				),

--- a/tests/php/integration/test-template-output.php
+++ b/tests/php/integration/test-template-output.php
@@ -156,7 +156,7 @@ class Test_Template_Output extends Abstract_Attribute {
 		foreach ( $this->string_fields as $field ) {
 			$this->assertContains(
 				sprintf(
-					esc_html( 'And here is the result of calling block_value() for %s: %s', 'bl-testing-templates' ),
+					'And here is the result of calling block_value() for %s: %s',
 					$field,
 					$this->attributes[ $field ]
 				),
@@ -165,7 +165,7 @@ class Test_Template_Output extends Abstract_Attribute {
 
 			$this->assertContains(
 				sprintf(
-					esc_html( 'Here is the result of block_field() for %s: %s', 'bl-testing-templates' ),
+					'Here is the result of block_field() for %s: %s',
 					$field,
 					$this->attributes[ $field ]
 				),

--- a/tests/php/integration/test-template-output.php
+++ b/tests/php/integration/test-template-output.php
@@ -5,36 +5,15 @@
  * @package Block_Lab
  */
 
-use Block_Lab\Post_Types;
 use Block_Lab\Blocks;
+use Block_Lab\Post_Types;
 
 /**
  * Class Test_Template_Output
  *
- * @package Template_Output
+ * @package Block_Lab
  */
-class Test_Template_Output extends \WP_UnitTestCase {
-
-	/**
-	 * The block attributes.
-	 *
-	 * @var array
-	 */
-	public $attributes;
-
-	/**
-	 * All fields that return a string for block_value().
-	 *
-	 * @var array
-	 */
-	public $string_fields;
-
-	/**
-	 * All fields that return either an object or ID for block_value().
-	 *
-	 * @var array
-	 */
-	public $object_fields;
+class Test_Template_Output extends Abstract_Attribute {
 
 	/**
 	 * Fields that don't fit well into the other test groups.
@@ -44,80 +23,11 @@ class Test_Template_Output extends \WP_UnitTestCase {
 	public $special_case_fields;
 
 	/**
-	 * The instance of Loader, to render the template.
-	 *
-	 * @var Blocks\Loader
-	 */
-	public $loader;
-
-	/**
-	 * The name of the block that tests all fields.
-	 *
-	 * @var string
-	 */
-	public $block_name;
-
-	/**
-	 * The name of the block with the prefix.
-	 *
-	 * @var string
-	 */
-	public $prefixed_block_name;
-
-	/**
-	 * The path to the blocks/ directory in the theme.
-	 *
-	 * @var string
-	 */
-	public $blocks_directory;
-
-	/**
-	 * The location of the block template.
-	 *
-	 * @var string
-	 */
-	public $template_location;
-
-	/**
-	 * The block class name.
-	 *
-	 * @var string
-	 */
-	public $class_name = 'example-name';
-
-	/**
-	 * Setup.
-	 *
-	 * @inheritdoc
-	 */
-	public function setUp() {
-		parent::setUp();
-
-		$this->set_properties();
-		$this->create_block_template();
-	}
-
-	/**
-	 * Teardown.
-	 *
-	 * @inheritdoc
-	 */
-	public function tearDown() {
-		parent::setUp();
-
-		if ( file_exists( $this->template_location ) ) {
-			unlink( $this->template_location );
-		}
-		if ( is_dir( $this->blocks_directory ) ) {
-			rmdir( $this->blocks_directory );
-		}
-	}
-
-	/**
 	 * Sets class properties.
 	 */
 	public function set_properties() {
-		$this->loader = new Blocks\Loader();
+		$this->block_name = 'all-fields-except-repeater';
+		$this->loader     = new Blocks\Loader();
 
 		$this->attributes = array(
 			'className'   => $this->class_name,
@@ -125,7 +35,7 @@ class Test_Template_Output extends \WP_UnitTestCase {
 			'text'        => 'Here is a text field',
 			'textarea'    => 'And here is something',
 			'url'         => 'https://yourdomain.com/entered',
-			'email'       => 'entered@emal.com',
+			'email'       => 'entered@email.com',
 			'number'      => 15134,
 			'color'       => '#777444',
 			'image'       => $this->get_image_attribute(),
@@ -183,80 +93,6 @@ class Test_Template_Output extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Creates the block template.
-	 *
-	 * Instead of copying the fixture entirely into the theme directory,
-	 * this puts an include statement in it, pointing to the fixture.
-	 */
-	public function create_block_template() {
-		$this->block_name          = 'all-fields-except-repeater';
-		$this->prefixed_block_name = "block-lab/{$this->block_name}";
-		$theme_directory           = get_template_directory();
-		$template_path_in_fixtures = __DIR__ . "/fixtures/{$this->block_name}.php";
-		$this->blocks_directory    = "{$theme_directory}/blocks";
-		$this->template_location   = "{$this->blocks_directory}/block-{$this->block_name}.php";
-
-		mkdir( $this->blocks_directory );
-		$template_contents = sprintf( "<?php include '%s';", $template_path_in_fixtures );
-		file_put_contents( $this->template_location, $template_contents ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
-	}
-
-	/**
-	 * Gets the post attributes.
-	 *
-	 * @return array
-	 */
-	public function get_post_attributes() {
-		$id = $this->factory()->post->create();
-
-		return array(
-			'id'   => $id,
-			'name' => get_the_title( $id ),
-		);
-	}
-
-	/**
-	 * Gets the taxonomy attributes.
-	 *
-	 * @return array
-	 */
-	public function get_taxonomy_attributes() {
-		$term = $this->factory()->tag->create_and_get();
-
-		return array(
-			'id'   => $term->term_id,
-			'name' => $term->name,
-		);
-	}
-
-	/**
-	 * Gets the user attributes.
-	 *
-	 * @return array
-	 */
-	public function get_user_attributes() {
-		$user = $this->factory()->user->create_and_get();
-
-		return array(
-			'id'       => $user->ID,
-			'userName' => $user->display_name,
-		);
-	}
-
-	/**
-	 * Gets the image attribute.
-	 *
-	 * @return int The image's ID.
-	 */
-	public function get_image_attribute() {
-		return $this->factory()->attachment->create_object(
-			array( 'file' => 'baz.jpeg' ),
-			0,
-			array( 'post_mime_type' => 'image/jpeg' )
-		);
-	}
-
-	/**
 	 * Gets the block config.
 	 *
 	 * @return array The config for the block.
@@ -268,7 +104,7 @@ class Test_Template_Output extends \WP_UnitTestCase {
 		$all_fields = array_merge(
 			$this->string_fields,
 			$this->object_fields,
-			array_keys( $this->special_case_fields )
+			$this->special_case_field_names
 		);
 
 		foreach ( $all_fields as $field_name ) {
@@ -354,7 +190,7 @@ class Test_Template_Output extends \WP_UnitTestCase {
 
 		/*
 		 * The fields here return objects for block_value(), so test that some of the properties are correct.
-		 * For example, block_value( 'post' )->id.
+		 * For example, block_value( 'post' )->ID.
 		 */
 		foreach ( $object_fields as $name => $field ) {
 			foreach ( $field['properties'] as $property ) {


### PR DESCRIPTION
* Adds an integration test for the repeater, with 2 rows of all possible controls.
* Though it doesn't test default values yet.
* [Adds a filter](https://github.com/getblocklab/block-lab/pull/419/files#diff-018b57db3c29f17ff59f382617e39f14R75) similar to the one for `block_field()`
* That filter is how each control's `validate()` function is called when calling `block_sub_field()` or `block_field()`
* For example, for the Image control, [Image::validate()](https://github.com/getblocklab/block-lab/blob/60e63eb6549a7fa1693d64e619278ae422de4b4f/php/blocks/controls/class-image.php#L59) outputs a different value if `$echo` is true (the URL), versus when it's false (the ID).

Closes #418 
Partially fulfills #404 (Add an integration test for the repeater)