### PR TITLE
Add min and max row setting to repeater field

### DIFF
--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -272,12 +272,16 @@ div[class^="wp-block-block-lab-"] {
               width: 100%;
             }
 
-            &:hover {
+            &:hover:not(:disabled) {
               color: $alert-red;
             }
 
-            &:active {
+            &:active:not(:disabled) {
               color: $dark-gray-600;
+            }
+
+            &:disabled {
+              opacity: 0;
             }
           }
         }
@@ -336,11 +340,14 @@ div[class^="wp-block-block-lab-"] {
       display: flex;
       justify-content: center;
 
-      .components-icon-button:hover {
+      .components-icon-button:hover:not(:disabled) {
         border-color: transparent;
         box-shadow: none;
         background: transparent;
         color: $blue-medium-focus;
+      }
+      .components-icon-button:active:disabled {
+        color: #555d66;
       }
     }
   }

--- a/js/blocks/components/repeater-rows.js
+++ b/js/blocks/components/repeater-rows.js
@@ -170,7 +170,7 @@ import { Fields } from './';
 											className="button-delete"
 											label={ __( 'Delete', 'block-lab' ) }
 											onClick={ this.removeRow( rowIndex ) }
-											disabled={ rows.length <= field.min ? true : false }
+											disabled={ !! field.min && rows.length <= field.min }
 											isSmall
 										/>
 									</div>

--- a/js/blocks/components/repeater-rows.js
+++ b/js/blocks/components/repeater-rows.js
@@ -152,7 +152,7 @@ import { Fields } from './';
 	 * Renders the repeater rows.
 	 */
 	render() {
-		const { rows, subFields, parentBlockProps, parentBlock } = this.props;
+		const { rows, field, subFields, parentBlockProps, parentBlock } = this.props;
 
 		return (
 			<Fragment>
@@ -170,6 +170,7 @@ import { Fields } from './';
 											className="button-delete"
 											label={ __( 'Delete', 'block-lab' ) }
 											onClick={ this.removeRow( rowIndex ) }
+											disabled={ rows.length <= field.min ? true : false }
 											isSmall
 										/>
 									</div>

--- a/js/blocks/controls/repeater.js
+++ b/js/blocks/controls/repeater.js
@@ -14,7 +14,7 @@ const BlockLabRepeaterControl = ( props ) => {
 	const { attributes, setAttributes } = parentBlockProps;
 	const attr = { ...attributes };
 	const value = attr[ field.name ];
-	const defaultRows = [ {} ];
+	const defaultRows = new Array( field.min ? field.min : 1 ).fill( { '': '' } );
 	const hasRows = value && value.hasOwnProperty( 'rows' );
 	const rows = hasRows ? value.rows : defaultRows;
 
@@ -35,10 +35,12 @@ const BlockLabRepeaterControl = ( props ) => {
 	if ( ! hasRows ) {
 		onChange( { rows: defaultRows } );
 	}
+
 	return (
 		<BaseControl className="block-lab-repeater" label={ field.label } help={ field.help }>
 			<RepeaterRows
 				rows={ rows }
+				field={ field }
 				subFields={ field.sub_fields || defaultRows }
 				parentBlockProps={ parentBlockProps }
 				parentBlock={ parentBlock }
@@ -50,7 +52,7 @@ const BlockLabRepeaterControl = ( props ) => {
 					label={ __( 'Add new', 'block-lab' ) }
 					labelPosition="bottom"
 					onClick={ addEmptyRow }
-					disabled={ false }
+					disabled={ rows.length >= field.max ? true : false }
 				/>
 			</div>
 		</BaseControl>

--- a/js/blocks/controls/repeater.js
+++ b/js/blocks/controls/repeater.js
@@ -52,7 +52,7 @@ const BlockLabRepeaterControl = ( props ) => {
 					label={ __( 'Add new', 'block-lab' ) }
 					labelPosition="bottom"
 					onClick={ addEmptyRow }
-					disabled={ rows.length >= field.max ? true : false }
+					disabled={ !! field.max && rows.length >= field.max }
 				/>
 			</div>
 		</BaseControl>

--- a/php/blocks/controls/class-repeater.php
+++ b/php/blocks/controls/class-repeater.php
@@ -46,5 +46,23 @@ class Repeater extends Control_Abstract {
 	 */
 	public function register_settings() {
 		$this->settings[] = new Control_Setting( $this->settings_config['help'] );
+		$this->settings[] = new Control_Setting(
+			array(
+				'name'     => 'min',
+				'label'    => __( 'Minimum Rows', 'block-lab' ),
+				'type'     => 'number_non_negative',
+				'default'  => '',
+				'sanitize' => array( $this, 'sanitize_number' ),
+			)
+		);
+		$this->settings[] = new Control_Setting(
+			array(
+				'name'     => 'max',
+				'label'    => __( 'Maximum Rows', 'block-lab' ),
+				'type'     => 'number_non_negative',
+				'default'  => '',
+				'sanitize' => array( $this, 'sanitize_number' ),
+			)
+		);
 	}
 }

--- a/php/blocks/controls/class-repeater.php
+++ b/php/blocks/controls/class-repeater.php
@@ -51,7 +51,6 @@ class Repeater extends Control_Abstract {
 				'name'     => 'min',
 				'label'    => __( 'Minimum Rows', 'block-lab' ),
 				'type'     => 'number_non_negative',
-				'default'  => '',
 				'sanitize' => array( $this, 'sanitize_number' ),
 			)
 		);
@@ -60,7 +59,6 @@ class Repeater extends Control_Abstract {
 				'name'     => 'max',
 				'label'    => __( 'Maximum Rows', 'block-lab' ),
 				'type'     => 'number_non_negative',
-				'default'  => '',
 				'sanitize' => array( $this, 'sanitize_number' ),
 			)
 		);

--- a/tests/php/unit/blocks/controls/test-class-repeater.php
+++ b/tests/php/unit/blocks/controls/test-class-repeater.php
@@ -66,6 +66,26 @@ class Test_Repeater extends \WP_UnitTestCase {
 				'validate' => '',
 				'value'    => null,
 			),
+			array(
+				'name'     => 'min',
+				'label'    => 'Minimum Rows',
+				'type'     => 'number_non_negative',
+				'default'  => '',
+				'help'     => '',
+				'sanitize' => array( $this->instance, 'sanitize_number' ),
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'max',
+				'label'    => 'Maximum Rows',
+				'type'     => 'number_non_negative',
+				'default'  => '',
+				'help'     => '',
+				'sanitize' => array( $this->instance, 'sanitize_number' ),
+				'validate' => '',
+				'value'    => null,
+			),
 		);
 
 		$this->assert_correct_settings( $expected_settings, $this->instance->settings );


### PR DESCRIPTION
Hey @kienstra – thanks for reviewing this.

This PR forces a minimum and maximum amount of rows for the repeater.

The example below is a repeater with a min setting of 4, and a max of 6. Notice how it pre-populates the repeater with the minimum amount of rows. The "New Row" button is disabled when the maximum limit is reached, and the "delete" button is hidden when the minimum limit is reached.

![2019-09-09 19-50-00 2019-09-09 19_50_41](https://user-images.githubusercontent.com/1097667/64521501-71f62a00-d33b-11e9-8d32-f2673d428137.gif)

@RobStino Please review this for UX.

Closes #399.