### PR TITLE
Version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog #
 
+### 1.4.1 – 2019-09-11 ###
+
+You can now add a Minimum and Maximum Rows setting to repeaters, allowing you to specify a lower and upper limit on how many repeater rows can be added.
+
+* New: The repeater field now includes a minimum and maximum row setting
+* Fix: Location and Width settings are now visible again when adding a new field
+* Fix: Using block_sub_field() with an image now correctly outputs the image URL instead of the ID
+
 ### 1.4.0 – 2019-09-04 ###
 
 This release applies some finishing touches to the repeater field. It also introduces a new "Field Width" feature, which lets you choose the width of the fields as seen in the Editor.

--- a/block-lab.php
+++ b/block-lab.php
@@ -9,7 +9,7 @@
  * Plugin Name: Block Lab
  * Plugin URI: https://getblocklab.com
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.4.0
+ * Version: 1.4.1
  * Author: Block Lab
  * Author URI: https://getblocklab.com
  * License: GPL2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "block-lab",
   "title": "Block Lab",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "homepage": "https://getblocklab.com",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 1.4.1 – 2019-09-11 ###

You can now add a Minimum and Maximum Rows setting to repeaters, allowing you to specify a lower and upper limit on how many repeater rows can be added.

* New: The repeater field now includes a minimum and maximum row setting
* Fix: Location and Width settings are now visible again when adding a new field
* Fix: Using block_sub_field() with an image now correctly outputs the image URL instead of the ID
