### PR TITLE
Add Classic Text control, including list controls

### DIFF
--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -220,6 +220,7 @@ div[class^="wp-block-block-lab-"] {
       border-radius: 4px;
       border: 1px solid $dark-gray-150;
       outline: none;
+      min-height: 6rem;
 
       &:focus {
         border-color: $blue-medium-500;

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -176,9 +176,16 @@ div[class^="wp-block-block-lab-"] {
 
   /* Rich Text Control Component */
   .block-lab-rich-text-control .rich-text__edit {
-    background-color: $light-gray-500;
+    background-color: #fff;
     padding: 0.1rem 1rem;
+    border-radius: 4px;
+    border: 1px solid $dark-gray-150;
     outline: none;
+
+    &:focus {
+      border-color: $blue-medium-500;
+      box-shadow: 0 0 0 1px $blue-medium-500;
+    }
 
     p {
       font-size: 13px;

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -204,34 +204,9 @@ div[class^="wp-block-block-lab-"] {
   /* Classic Text Control Component */
   .block-lab-classic-text-control {
     .classic-text__toolbar {
-      /* Taken from the styling for the <RichText> component buttons. */
-      .mce-btn:not(:disabled):not([aria-disabled="true"]) {
-
-        &:hover {
-          background-color: $white;
-          color: $dark-gray-900;
-        }
-
-        &.mce-active button {
-          box-shadow: none;
-          background: $dark-gray-500;
-
-          .mce-ico {
-            color: $white;
-          }
-        }
-      }
-
-      .mce-tinymce {
-        box-shadow: none;
-      }
 
       > .mce-container {
         margin: 0 auto 2px auto;
-      }
-
-      .mce-btn-group .mce-btn {
-        border-radius: 4px;
       }
 
       .mce-toolbar-grp {

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -175,32 +175,18 @@ div[class^="wp-block-block-lab-"] {
   }
 
   /* Rich Text Control Component */
-  .block-lab-rich-text-control {
-    .rich-text__edit {
-      background-color: #a9a9a94d;
-    }
-    .input-control {
-      background: #fff;
-      min-height: 7em;
-      line-height: 1.4rem;
+  .block-lab-rich-text-control .rich-text__edit {
+    background-color: $light-gray-500;
+    padding: 0.1rem 1rem;
+
+    p {
       font-size: 13px;
-
-      p {
-        font-size: 13px;
-        margin-top: 0.67rem;
-        margin-bottom: 0.67rem;
-      }
-
-      p:first-child,
-      p:first-child > p {
-        margin-top: 0;
-      }
+      margin-top: 0.67rem;
+      margin-bottom: 0.67rem;
     }
 
-    /* Override native styling that created a double border */
-    .editor-rich-text__inline-toolbar .components-toolbar > .components-toolbar {
-      border: none;
-      border-right: 1px solid $light-gray-500;
+    ul {
+      margin-left: 1rem;
     }
   }
 

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -176,8 +176,34 @@ div[class^="wp-block-block-lab-"] {
 
   /* Rich Text Control Component */
   .block-lab-rich-text-control {
+    .input-control {
+      background: #fff;
+      min-height: 7em;
+      line-height: 1.4rem;
+      font-size: 13px;
 
-    .rich-text__toolbar {
+      p {
+        font-size: 13px;
+        margin-top: 0.67rem;
+        margin-bottom: 0.67rem;
+      }
+
+      p:first-child,
+      p:first-child > p {
+        margin-top: 0;
+      }
+    }
+
+    /* Override native styling that created a double border */
+    .editor-rich-text__inline-toolbar .components-toolbar > .components-toolbar {
+      border: none;
+      border-right: 1px solid $light-gray-500;
+    }
+  }
+
+  /* Classic Text Control Component */
+  .block-lab-classic-text-control {
+    .classic-text__toolbar {
       /* Taken from the styling for the <RichText> component buttons. */
       .mce-btn:not(:disabled):not([aria-disabled="true"]) {
 
@@ -214,7 +240,7 @@ div[class^="wp-block-block-lab-"] {
     }
 
     /* The editing area, not the toolbar. */
-    .rich-text__edit {
+    .classic-text__edit {
       background-color: #fff;
       padding: 0.1rem 1rem;
       border-radius: 4px;

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -207,14 +207,17 @@ div[class^="wp-block-block-lab-"] {
       .classic-text__toolbar {
       position: relative;
       z-index: 10;
-      top: 2px;
+      top: 1px;
 
       > .mce-container {
-        margin: 1px;
-        box-shadow: none;;
+        width: 100% !important;
+        border: 1px solid #c5c5c5;
+        box-shadow: none;
+        box-sizing: border-box;
       }
 
       .mce-container-body {
+        width: 100% !important;
         > .mce-container {
           width: 100% !important;
         }

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -460,3 +460,10 @@ div[class^="wp-block-block-lab-"] {
   margin: 0;
   padding-right: 1em;
 }
+
+// In the <ServerSideRender> display, correct an issue where <ul> and <ol> can appear outside (to the left) of their container.
+.editor-styles-wrapper .block-lab-editor__ssr {
+  ul, ol {
+    margin-left: 1rem;
+  }
+}

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -204,28 +204,34 @@ div[class^="wp-block-block-lab-"] {
   /* Classic Text Control Component */
   .block-lab-classic-text-control {
     .classic-text__toolbar {
+      position: relative;
+      z-index: 10;
+      top: 2px;
 
       > .mce-container {
-        margin: 0 auto 2px auto;
+        margin: 1px;
+        box-shadow: none;;
       }
 
-      .mce-toolbar-grp {
-        background-color: $white;
+      .mce-container-body {
+        > .mce-container {
+          width: 100% !important;
+        }
       }
     }
 
     /* The editing area, not the toolbar. */
     .classic-text__edit {
-      background-color: #fff;
-      padding: 0.1rem 1rem;
-      border-radius: 4px;
+      background: $white;
+      margin-top: -2.6rem;
+      padding: 2.8rem 1rem 0.2rem;
       border: 1px solid $dark-gray-150;
       outline: none;
       min-height: 6rem;
 
       &:focus {
-        border-color: $blue-medium-500;
-        box-shadow: 0 0 0 1px $blue-medium-500;
+        border-color: $blue-medium-focus;
+        box-shadow: 0 0 0 1px $blue-medium-focus;
       }
 
       /* Clear the float in case an image is floated. */

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -177,22 +177,43 @@ div[class^="wp-block-block-lab-"] {
   /* Rich Text Control Component */
   .block-lab-rich-text-control {
 
-    .mce-tinymce {
-      box-shadow: none;
+    .rich-text__toolbar {
+      /* Taken from the styling for the <RichText> component buttons. */
+      .mce-btn:not(:disabled):not([aria-disabled="true"]) {
+
+        &:hover {
+          background-color: $white;
+          color: $dark-gray-900;
+        }
+
+        &.mce-active button {
+          box-shadow: none;
+          background: $dark-gray-500;
+
+          .mce-ico {
+            color: $white;
+          }
+        }
+      }
+
+      .mce-tinymce {
+        box-shadow: none;
+      }
+
+      > .mce-container {
+        margin: 0 auto 2px auto;
+      }
+
+      .mce-btn-group .mce-btn {
+        border-radius: 4px;
+      }
+
+      .mce-toolbar-grp {
+        background-color: $white;
+      }
     }
 
-    .rich-text__toolbar > .mce-container {
-      margin: 0 auto 2px auto;
-    }
-
-    .mce-btn-group .mce-btn {
-      border-radius: 4px;
-    }
-
-    .mce-toolbar-grp {
-      background-color: $white;
-    }
-
+    /* The editing area, not the toolbar. */
     .rich-text__edit {
       background-color: #fff;
       padding: 0.1rem 1rem;

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -178,6 +178,7 @@ div[class^="wp-block-block-lab-"] {
   .block-lab-rich-text-control .rich-text__edit {
     background-color: $light-gray-500;
     padding: 0.1rem 1rem;
+    outline: none;
 
     p {
       font-size: 13px;
@@ -185,8 +186,15 @@ div[class^="wp-block-block-lab-"] {
       margin-bottom: 0.67rem;
     }
 
-    ul {
+    ul, ol {
       margin-left: 1rem;
+    }
+
+    /* Clear the float in case an image is floated. */
+    &:after {
+      content: "";
+      display: table;
+      clear: both;
     }
   }
 

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -175,33 +175,52 @@ div[class^="wp-block-block-lab-"] {
   }
 
   /* Rich Text Control Component */
-  .block-lab-rich-text-control .rich-text__edit {
-    background-color: #fff;
-    padding: 0.1rem 1rem;
-    border-radius: 4px;
-    border: 1px solid $dark-gray-150;
-    outline: none;
+  .block-lab-rich-text-control {
 
-    &:focus {
-      border-color: $blue-medium-500;
-      box-shadow: 0 0 0 1px $blue-medium-500;
+    .mce-tinymce {
+      box-shadow: none;
     }
 
-    p {
-      font-size: 13px;
-      margin-top: 0.67rem;
-      margin-bottom: 0.67rem;
+    .rich-text__toolbar > .mce-container {
+      margin: 0 auto 2px auto;
     }
 
-    ul, ol {
-      margin-left: 1rem;
+    .mce-btn-group .mce-btn {
+      border-radius: 4px;
     }
 
-    /* Clear the float in case an image is floated. */
-    &:after {
-      content: "";
-      display: table;
-      clear: both;
+    .mce-toolbar-grp {
+      background-color: $white;
+    }
+
+    .rich-text__edit {
+      background-color: #fff;
+      padding: 0.1rem 1rem;
+      border-radius: 4px;
+      border: 1px solid $dark-gray-150;
+      outline: none;
+
+      &:focus {
+        border-color: $blue-medium-500;
+        box-shadow: 0 0 0 1px $blue-medium-500;
+      }
+
+      /* Clear the float in case an image is floated. */
+      &:after {
+        content: "";
+        display: table;
+        clear: both;
+      }
+
+      p {
+        font-size: 13px;
+        margin-top: 0.67rem;
+        margin-bottom: 0.67rem;
+      }
+
+      ul, ol {
+        margin-left: 1rem;
+      }
     }
   }
 

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -176,6 +176,9 @@ div[class^="wp-block-block-lab-"] {
 
   /* Rich Text Control Component */
   .block-lab-rich-text-control {
+    .rich-text__edit {
+      background-color: #a9a9a94d;
+    }
     .input-control {
       background: #fff;
       min-height: 7em;

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -203,7 +203,8 @@ div[class^="wp-block-block-lab-"] {
 
   /* Classic Text Control Component */
   .block-lab-classic-text-control {
-    .classic-text__toolbar {
+
+      .classic-text__toolbar {
       position: relative;
       z-index: 10;
       top: 2px;
@@ -222,17 +223,12 @@ div[class^="wp-block-block-lab-"] {
 
     /* The editing area, not the toolbar. */
     .classic-text__edit {
+
       background: $white;
-      margin-top: -2.6rem;
-      padding: 2.8rem 1rem 0.2rem;
+      padding: 0.2rem 1rem;
       border: 1px solid $dark-gray-150;
       outline: none;
       min-height: 6rem;
-
-      &:focus {
-        border-color: $blue-medium-focus;
-        box-shadow: 0 0 0 1px $blue-medium-focus;
-      }
 
       /* Clear the float in case an image is floated. */
       &:after {

--- a/js/blocks/components/edit.js
+++ b/js/blocks/components/edit.js
@@ -39,6 +39,7 @@ const Edit = ( { blockProps, block } ) => {
 					<ServerSideRender
 						block={ `block-lab/${ block.name }` }
 						attributes={ attributes }
+						className="block-lab-editor__ssr"
 					/>
 				) }
 			</div>

--- a/js/blocks/components/index.js
+++ b/js/blocks/components/index.js
@@ -7,3 +7,4 @@ export { default as Fields } from './fields';
 export { default as FormControls } from './form-controls';
 export { default as Image } from './image';
 export { default as RepeaterRows } from './repeater-rows';
+export { default as TinyMCE } from './tiny-mce';

--- a/js/blocks/components/tiny-mce.js
+++ b/js/blocks/components/tiny-mce.js
@@ -185,7 +185,7 @@ class TinyMCE extends Component {
 				id={ `toolbar-${ editorId }` }
 				className="classic-text__toolbar"
 				onClick={ this.focus }
-				data-placeholder={ __( 'Rich text', 'block-lab' ) }
+				data-placeholder={ __( 'Classic text', 'block-lab' ) }
 				onKeyDown={ this.onToolbarKeyDown }
 			/>,
 			<div

--- a/js/blocks/components/tiny-mce.js
+++ b/js/blocks/components/tiny-mce.js
@@ -183,7 +183,7 @@ class TinyMCE extends Component {
 			<div
 				key="toolbar"
 				id={ `toolbar-${ editorId }` }
-				className="rich-text__toolbar"
+				className="classic-text__toolbar"
 				onClick={ this.focus }
 				data-placeholder={ __( 'Rich text', 'block-lab' ) }
 				onKeyDown={ this.onToolbarKeyDown }
@@ -191,7 +191,7 @@ class TinyMCE extends Component {
 			<div
 				key="editor"
 				id={ `editor-${ editorId }` }
-				className="rich-text__edit"
+				className="classic-text__edit"
 			/>,
 		];
 		/* eslint-enable jsx-a11y/no-static-element-interactions */

--- a/js/blocks/components/tiny-mce.js
+++ b/js/blocks/components/tiny-mce.js
@@ -137,13 +137,7 @@ class TinyMCE extends Component {
 		} );
 
 		editor.on( 'init', () => {
-			const rootNode = this.editor.getBody();
-
-			// Create the toolbar by refocussing the editor.
-			if ( document.activeElement === rootNode ) {
-				rootNode.blur();
-				this.editor.focus();
-			}
+			this.editor.focus();
 		} );
 	}
 

--- a/js/blocks/components/tiny-mce.js
+++ b/js/blocks/components/tiny-mce.js
@@ -131,7 +131,7 @@ class TinyMCE extends Component {
 		} );
 
 		editor.addButton( 'wp_add_media', {
-			tooltip: __( 'Insert Media' ),
+			tooltip: __( 'Insert Media', 'block-lab' ),
 			icon: 'dashicon dashicons-admin-media',
 			cmd: 'WP_Medialib',
 		} );

--- a/js/blocks/components/tiny-mce.js
+++ b/js/blocks/components/tiny-mce.js
@@ -137,7 +137,13 @@ class TinyMCE extends Component {
 		} );
 
 		editor.on( 'init', () => {
-			this.editor.focus();
+			const rootNode = this.editor.getBody();
+
+			// Create the toolbar by refocussing the editor.
+			if ( document.activeElement === rootNode ) {
+				rootNode.blur();
+				this.editor.focus();
+			}
 		} );
 	}
 

--- a/js/blocks/components/tiny-mce.js
+++ b/js/blocks/components/tiny-mce.js
@@ -137,11 +137,18 @@ class TinyMCE extends Component {
 		} );
 
 		editor.on( 'init', () => {
-			const rootNode = this.editor.getBody();
+			const { activeElement } = document;
 
-			// Create the toolbar by refocussing the editor.
-			rootNode.blur();
-			this.editor.focus();
+			// Force focus to the editor, as this seems to be the only way to display the toolbar.
+			// @see https://github.com/WordPress/gutenberg/pull/4948
+			this.editor.fire( 'focus' );
+
+			// Refocus to whatever was in focus before the editor, likely most of the block.
+			editor.once( 'focus', () => {
+				if ( activeElement !== this.editor.getBody() ) {
+					activeElement.focus();
+				}
+			} );
 		} );
 	}
 

--- a/js/blocks/components/tiny-mce.js
+++ b/js/blocks/components/tiny-mce.js
@@ -137,18 +137,11 @@ class TinyMCE extends Component {
 		} );
 
 		editor.on( 'init', () => {
-			const { activeElement } = document;
+			const rootNode = this.editor.getBody();
 
-			// Force focus to the editor, as this seems to be the only way to display the toolbar.
-			// @see https://github.com/WordPress/gutenberg/pull/4948
-			this.editor.fire( 'focus' );
-
-			// Refocus to whatever was in focus before the editor, likely most of the block.
-			editor.once( 'focus', () => {
-				if ( activeElement !== this.editor.getBody() ) {
-					activeElement.focus();
-				}
-			} );
+			// Create the toolbar by refocussing the editor.
+			rootNode.blur();
+			this.editor.focus();
 		} );
 	}
 

--- a/js/blocks/components/tiny-mce.js
+++ b/js/blocks/components/tiny-mce.js
@@ -75,7 +75,7 @@ class TinyMCE extends Component {
 				content_css: false,
 				fixed_toolbar_container: `#toolbar-${ editorId }`,
 				setup: this.onSetup,
-				toolbar1: 'bold,italic,bullist,numlist,outdent,indent,alignleft,aligncenter,alignright,link,unlink,wp_add_media',
+				toolbar1: 'bold,italic,bullist,numlist,outdent,indent,alignleft,aligncenter,alignright,link,unlink,wp_add_media,strikethrough',
 				toolbar2: '',
 			},
 		} );

--- a/js/blocks/components/tiny-mce.js
+++ b/js/blocks/components/tiny-mce.js
@@ -3,30 +3,14 @@
  */
 const { Component } = wp.element;
 const { __ } = wp.i18n;
-const { BACKSPACE, DELETE, F10 } = wp.keycodes;
-
-function isTmceEmpty( editor ) {
-	// When tinyMce is empty the content seems to be:
-	// <p><br data-mce-bogus="1"></p>
-	// avoid expensive checks for large documents
-	const body = editor.getBody();
-	if ( body.childNodes.length > 1 ) {
-		return false;
-	} else if ( body.childNodes.length === 0 ) {
-		return true;
-	}
-	if ( body.childNodes[ 0 ].childNodes.length > 1 ) {
-		return false;
-	}
-	return /^\n?$/.test( body.innerText || body.textContent );
-}
+const { F10 } = wp.keycodes;
 
 /**
  * Forked from the Core Classic Editor's Edit component.
  *
  * @see https://github.com/WordPress/gutenberg/blob/416c9bc9eaef6e6bceea923b6f36642746c01aba/packages/block-library/src/classic/edit.js
  */
-export default class TinyMCE extends Component {
+class TinyMCE extends Component {
 	/**
 	 * Constructs the class.
 	 *
@@ -133,18 +117,12 @@ export default class TinyMCE extends Component {
 			bookmark = null;
 		} );
 
+		// Different from the Core Classic block, prevents losing edits when viewing the <ServerSideRender>.
 		editor.on( 'change', () => {
 			onChange( editor.getContent() );
 		} );
 
 		editor.on( 'keydown', ( event ) => {
-			if ( ( event.keyCode === BACKSPACE || event.keyCode === DELETE ) && isTmceEmpty( editor ) ) {
-				// delete the block
-				this.props.onReplace( [] );
-				event.preventDefault();
-				event.stopImmediatePropagation();
-			}
-
 			const { altKey } = event;
 			/*
 			 * Prevent Mousetrap from kicking in: TinyMCE already uses its own
@@ -225,3 +203,5 @@ export default class TinyMCE extends Component {
 		/* eslint-enable jsx-a11y/no-static-element-interactions */
 	}
 }
+
+export default TinyMCE;

--- a/js/blocks/components/tiny-mce.js
+++ b/js/blocks/components/tiny-mce.js
@@ -1,0 +1,195 @@
+/**
+ * WordPress dependencies
+ */
+const { Component } = wp.element;
+const { __ } = wp.i18n;
+const { BACKSPACE, DELETE, F10 } = wp.keycodes;
+
+function isTmceEmpty( editor ) {
+	// When tinyMce is empty the content seems to be:
+	// <p><br data-mce-bogus="1"></p>
+	// avoid expensive checks for large documents
+	const body = editor.getBody();
+	if ( body.childNodes.length > 1 ) {
+		return false;
+	} else if ( body.childNodes.length === 0 ) {
+		return true;
+	}
+	if ( body.childNodes[ 0 ].childNodes.length > 1 ) {
+		return false;
+	}
+	return /^\n?$/.test( body.innerText || body.textContent );
+}
+
+/**
+ * Forked from the Core Classic Editor's Edit component.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/416c9bc9eaef6e6bceea923b6f36642746c01aba/packages/block-library/src/classic/edit.js
+ */
+export default class TinyMCE extends Component {
+	constructor( props ) {
+		super( props );
+		this.initialize = this.initialize.bind( this );
+		this.onSetup = this.onSetup.bind( this );
+		this.focus = this.focus.bind( this );
+	}
+
+	componentDidMount() {
+		const { baseURL, suffix } = window.wpEditorL10n.tinymce;
+
+		window.tinymce.EditorManager.overrideDefaults( {
+			base_url: baseURL,
+			suffix,
+		} );
+
+		if ( document.readyState === 'complete' ) {
+			this.initialize();
+		} else {
+			window.addEventListener( 'DOMContentLoaded', this.initialize );
+		}
+	}
+
+	componentWillUnmount() {
+		window.addEventListener( 'DOMContentLoaded', this.initialize );
+		wp.oldEditor.remove( `editor-${ this.props.clientId }` );
+	}
+
+	componentDidUpdate( prevProps ) {
+		const { clientId, content } = this.props;
+
+		const editor = window.tinymce.get( `editor-${ clientId }` );
+
+		if ( prevProps.content !== content ) {
+			editor.setContent( content || '' );
+		}
+	}
+
+	initialize() {
+		const { clientId } = this.props;
+		const { settings } = window.wpEditorL10n.tinymce;
+		wp.oldEditor.initialize( `editor-${ clientId }`, {
+			tinymce: {
+				...settings,
+				inline: true,
+				content_css: false,
+				fixed_toolbar_container: `#toolbar-${ clientId }`,
+				setup: this.onSetup,
+				toolbar1: 'bold,italic,bullist,numlist,outdent,indent,alignleft,aligncenter,alignright,link,unlink,wp_add_media',
+				toolbar2: '',
+			},
+		} );
+	}
+
+	onSetup( editor ) {
+		const { content, onChange } = this.props;
+		const { ref } = this;
+		let bookmark;
+
+		this.editor = editor;
+
+		if ( content ) {
+			editor.on( 'loadContent', () => editor.setContent( content ) );
+		}
+
+		editor.on( 'blur', () => {
+			bookmark = editor.selection.getBookmark( 2, true );
+
+			onChange( editor.getContent() );
+
+			editor.once( 'focus', () => {
+				if ( bookmark ) {
+					editor.selection.moveToBookmark( bookmark );
+				}
+			} );
+
+			return false;
+		} );
+
+		editor.on( 'mousedown touchstart', () => {
+			bookmark = null;
+		} );
+
+		editor.on( 'keydown', ( event ) => {
+			if ( ( event.keyCode === BACKSPACE || event.keyCode === DELETE ) && isTmceEmpty( editor ) ) {
+				// delete the block
+				this.props.onReplace( [] );
+				event.preventDefault();
+				event.stopImmediatePropagation();
+			}
+
+			const { altKey } = event;
+			/*
+			 * Prevent Mousetrap from kicking in: TinyMCE already uses its own
+			 * `alt+f10` shortcut to focus its toolbar.
+			 */
+			if ( altKey && event.keyCode === F10 ) {
+				event.stopPropagation();
+			}
+		} );
+
+		// Show the second, third, etc. toolbars when the `kitchensink` button is removed by a plugin.
+		editor.on( 'init', function() {
+			if ( editor.settings.toolbar1 && editor.settings.toolbar1.indexOf( 'kitchensink' ) === -1 ) {
+				editor.dom.addClass( ref, 'has-advanced-toolbar' );
+			}
+		} );
+
+		editor.addButton( 'wp_add_media', {
+			tooltip: __( 'Insert Media' ),
+			icon: 'dashicon dashicons-admin-media',
+			cmd: 'WP_Medialib',
+		} );
+
+		editor.on( 'init', () => {
+			const rootNode = this.editor.getBody();
+
+			// Create the toolbar by refocussing the editor.
+			if ( document.activeElement === rootNode ) {
+				rootNode.blur();
+				this.editor.focus();
+			}
+		} );
+	}
+
+	focus() {
+		if ( this.editor ) {
+			this.editor.focus();
+		}
+	}
+
+	onToolbarKeyDown( event ) {
+		// Prevent WritingFlow from kicking in and allow arrows navigation on the toolbar.
+		event.stopPropagation();
+		// Prevent Mousetrap from moving focus to the top toolbar when pressing `alt+f10` on this block toolbar.
+		event.nativeEvent.stopImmediatePropagation();
+	}
+
+	render() {
+		const { clientId } = this.props;
+
+		// Disable reasons:
+		//
+		// jsx-a11y/no-static-element-interactions
+		//  - the toolbar itself is non-interactive, but must capture events
+		//    from the KeyboardShortcuts component to stop their propagation.
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
+		return [
+			<div
+				key="toolbar"
+				id={ `toolbar-${ clientId }` }
+				ref={ ( ref ) => this.ref = ref }
+				className="rich-text__toolbar"
+				onClick={ this.focus }
+				data-placeholder={ __( 'Classic', 'block-lab' ) }
+				onKeyDown={ this.onToolbarKeyDown }
+			/>,
+			<div
+				key="editor"
+				id={ `editor-${ clientId }` }
+				className="rich-text__edit block-library-rich-text__tinymce"
+			/>,
+		];
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
+	}
+}

--- a/js/blocks/components/tiny-mce.js
+++ b/js/blocks/components/tiny-mce.js
@@ -55,12 +55,9 @@ class TinyMCE extends Component {
 	 * @param {Object} prevProps The previous props of the component, before the update.
 	 */
 	componentDidUpdate( prevProps ) {
-		const { content, editorId, onChange } = this.props;
-
-		const editor = window.tinymce.get( `editor-${ editorId }` );
+		const { content, onChange } = this.props;
 
 		if ( prevProps.content !== content ) {
-			editor.setContent( content || '' );
 			onChange( content || '' );
 		}
 	}
@@ -188,16 +185,15 @@ class TinyMCE extends Component {
 			<div
 				key="toolbar"
 				id={ `toolbar-${ editorId }` }
-				ref={ ( ref ) => this.ref = ref }
 				className="rich-text__toolbar"
 				onClick={ this.focus }
-				data-placeholder={ __( 'Classic', 'block-lab' ) }
+				data-placeholder={ __( 'Rich text', 'block-lab' ) }
 				onKeyDown={ this.onToolbarKeyDown }
 			/>,
 			<div
 				key="editor"
 				id={ `editor-${ editorId }` }
-				className="rich-text__edit block-library-rich-text__tinymce"
+				className="rich-text__edit"
 			/>,
 		];
 		/* eslint-enable jsx-a11y/no-static-element-interactions */

--- a/js/blocks/components/tiny-mce.js
+++ b/js/blocks/components/tiny-mce.js
@@ -75,7 +75,7 @@ class TinyMCE extends Component {
 				content_css: false,
 				fixed_toolbar_container: `#toolbar-${ editorId }`,
 				setup: this.onSetup,
-				toolbar1: 'bold,italic,bullist,numlist,outdent,indent,alignleft,aligncenter,alignright,link,unlink,wp_add_media,strikethrough',
+				toolbar1: 'formatselect,bold,italic,bullist,numlist,outdent,indent,alignleft,aligncenter,alignright,link,unlink,wp_add_media,strikethrough',
 				toolbar2: '',
 			},
 		} );

--- a/js/blocks/components/tiny-mce.js
+++ b/js/blocks/components/tiny-mce.js
@@ -140,10 +140,8 @@ class TinyMCE extends Component {
 			const rootNode = this.editor.getBody();
 
 			// Create the toolbar by refocussing the editor.
-			if ( document.activeElement === rootNode ) {
-				rootNode.blur();
-				this.editor.focus();
-			}
+			rootNode.blur();
+			this.editor.focus();
 		} );
 	}
 

--- a/js/blocks/components/tiny-mce.js
+++ b/js/blocks/components/tiny-mce.js
@@ -140,8 +140,10 @@ class TinyMCE extends Component {
 			const rootNode = this.editor.getBody();
 
 			// Create the toolbar by refocussing the editor.
-			rootNode.blur();
-			this.editor.focus();
+			if ( document.activeElement === rootNode ) {
+				rootNode.blur();
+				this.editor.focus();
+			}
 		} );
 	}
 

--- a/js/blocks/controls/classic-text.js
+++ b/js/blocks/controls/classic-text.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+const { BaseControl } = wp.components;
+
+/**
+ * Internal dependencies
+ */
+import { TinyMCE } from '../components';
+
+const BlockLabClassicTextControl = ( props ) => {
+	const { field, getValue, instanceId, onChange } = props;
+
+	return (
+		<BaseControl
+			label={ field.label }
+			id={ `bl-rich-text-${ instanceId }` }
+			className="block-lab-classic-text-control"
+			help={ field.help }
+		>
+			<TinyMCE
+				content={ getValue( props ) }
+				onChange={ onChange }
+				editorId={ `rich-text-${ field.name }` }
+			/>
+		</BaseControl>
+	);
+};
+
+export default BlockLabClassicTextControl;

--- a/js/blocks/controls/classic-text.js
+++ b/js/blocks/controls/classic-text.js
@@ -14,14 +14,14 @@ const BlockLabClassicTextControl = ( props ) => {
 	return (
 		<BaseControl
 			label={ field.label }
-			id={ `bl-rich-text-${ instanceId }` }
+			id={ `bl-classic-text-${ instanceId }` }
 			className="block-lab-classic-text-control"
 			help={ field.help }
 		>
 			<TinyMCE
 				content={ getValue( props ) }
 				onChange={ onChange }
-				editorId={ `rich-text-${ field.name }` }
+				editorId={ `classic-text-${ field.name }` }
 			/>
 		</BaseControl>
 	);

--- a/js/blocks/controls/index.js
+++ b/js/blocks/controls/index.js
@@ -3,6 +3,7 @@
  */
 import BlockLabTextControl from './text';
 import BlockLabTextareaControl from './textarea';
+import BlockLabClassicTextControl from './classic-text';
 import BlockLabRichTextControl from './rich-text';
 import BlockLabURLControl from './url';
 import BlockLabEmailControl from './email';
@@ -23,6 +24,7 @@ import BlockLabUserControl from './user';
 export default {
 	text: BlockLabTextControl,
 	textarea: BlockLabTextareaControl,
+	classic_text: BlockLabClassicTextControl,
 	rich_text: BlockLabRichTextControl,
 	url: BlockLabURLControl,
 	email: BlockLabEmailControl,

--- a/js/blocks/controls/rich-text.js
+++ b/js/blocks/controls/rich-text.js
@@ -2,116 +2,11 @@
  * WordPress dependencies
  */
 const { BaseControl } = wp.components;
-const { RichText, RichTextToolbarButton } = wp.blockEditor;
-const { Fragment } = wp.element;
-const { __ } = wp.i18n;
-const {
-	__unstableChangeListType: changeListType,
-	__unstableIsListRootSelected: isListRootSelected,
-	__unstableIsActiveListType: isActiveListType,
-	applyFormat,
-	registerFormatType,
-	removeFormat,
-} = wp.richText;
-
-const listControlName = 'block-lab/rich-text-list-controls';
-const tagName = 'ul';
 
 /**
- * Gets the styling for a given alignment.
- *
- * @param {string} alignment The alignment, like 'left' or 'right'.
- * @return {string} The alignment style, like text-align: left;.
+ * Internal dependencies
  */
-const getListStyle = ( alignment ) => {
-	return `text-align: ${ alignment }`;
-};
-
-/**
- * The list buttons to set the <ul> and <li> format.
- *
- * @param {Object} props The component properties.
- * @param {Object} props.value The value.
- * @param {Function} props.onChange The handler for changes of the toolbar.
- */
-const ListToolbar = ( { value, onChange } ) => {
-	const setAttributes = () => {};
-
-	return (
-		<Fragment>
-			<RichTextToolbarButton
-				icon="editor-ul"
-				title={ __( 'Convert to unordered list', 'block-lab' ) }
-				isActive={ !! value && !! value.name && isActiveListType( value, 'ul', tagName ) }
-				onClick={ () => {
-					onChange( changeListType( value, { type: 'ul' } ) );
-
-					if ( isListRootSelected( value ) ) {
-						setAttributes( { ordered: false } );
-					}
-				} }
-			/>
-			<RichTextToolbarButton
-				icon="editor-ol"
-				title={ __( 'Convert to ordered list', 'block-lab' ) }
-				isActive={ !! value && !! value.name && isActiveListType( value, 'ol', tagName ) }
-				onClick={ () => {
-					onChange( changeListType( value, { type: 'ol' } ) );
-
-					if ( isListRootSelected( value ) ) {
-						setAttributes( { ordered: true } );
-					}
-				} }
-			/>
-		</Fragment>
-	);
-};
-
-registerFormatType(
-	listControlName,
-	{
-		title: __( 'List Type Controls', 'block-lab' ),
-		tagName,
-		className: 'bl-aligned',
-		attributes: {
-			align: 'style',
-		},
-		edit: ( { onChange, value } ) => {
-			return (
-				<ListToolbar
-					value={ value }
-					onChange={ ( newListType ) => {
-						if ( newListType ) {
-							onChange(
-								applyFormat(
-									value,
-									{
-										type: listControlName,
-										attributes: {
-											align: getListStyle( newListType ),
-										},
-									},
-								)
-							);
-						} else {
-							onChange(
-								removeFormat(
-									value,
-									{
-										type: listControlName,
-										attributes: {
-											align: getListStyle( value ),
-										},
-									},
-								)
-							);
-						}
-					} }
-				/>
-			);
-		},
-	}
-);
+import { TinyMCE } from '../components';
 
 const BlockLabRichTextControl = ( props ) => {
 	const { field, getValue, instanceId, onChange } = props;
@@ -123,22 +18,10 @@ const BlockLabRichTextControl = ( props ) => {
 			className="block-lab-rich-text-control"
 			help={ field.help }
 		>
-			{
-			/*
-			* @todo: Resolve known issue with toolbar not disappearing on blur
-			* @see: https://github.com/WordPress/gutenberg/issues/7463
-			*/
-			}
-			<RichText
-				key={ `block-lab-${ field.name }` }
-				placeholder={ field.placeholder || '' }
-				keepPlaceholderOnFocus={ true }
-				defaultValue={ field.default }
-				value={ getValue( props ) }
-				className="input-control"
-				multiline={ true }
-				inlineToolbar={ true }
+			<TinyMCE
+				content={ getValue( props ) }
 				onChange={ onChange }
+				clientId={ `rich-text-${ field.name }` }
 			/>
 		</BaseControl>
 	);

--- a/js/blocks/controls/rich-text.js
+++ b/js/blocks/controls/rich-text.js
@@ -2,8 +2,7 @@
  * WordPress dependencies
  */
 const { BaseControl } = wp.components;
-const { RichText } = wp.blockEditor;
-const { RichTextToolbarButton } = wp.blockEditor;
+const { RichText, RichTextToolbarButton } = wp.blockEditor;
 const { Fragment } = wp.element;
 const { __ } = wp.i18n;
 const {

--- a/js/blocks/controls/rich-text.js
+++ b/js/blocks/controls/rich-text.js
@@ -1,5 +1,118 @@
+/**
+ * WordPress dependencies
+ */
 const { BaseControl } = wp.components;
 const { RichText } = wp.blockEditor;
+const { RichTextToolbarButton } = wp.blockEditor;
+const { Fragment } = wp.element;
+const { __ } = wp.i18n;
+const {
+	__unstableChangeListType: changeListType,
+	__unstableIsListRootSelected: isListRootSelected,
+	__unstableIsActiveListType: isActiveListType,
+	applyFormat,
+	registerFormatType,
+	removeFormat,
+} = wp.richText;
+
+const listControlName = 'block-lab/rich-text-list-controls';
+const tagName = 'ul';
+
+/**
+ * Gets the styling for a given alignment.
+ *
+ * @param {string} alignment The alignment, like 'left' or 'right'.
+ * @return {string} The alignment style, like text-align: left;.
+ */
+const getListStyle = ( alignment ) => {
+	return `text-align: ${ alignment }`;
+};
+
+/**
+ * The list buttons to set the <ul> and <li> format.
+ *
+ * @param {Object} props The component properties.
+ * @param {Object} props.value The value.
+ * @param {Function} props.onChange The handler for changes of the toolbar.
+ */
+const ListToolbar = ( { value, onChange } ) => {
+	const setAttributes = () => {};
+
+	return (
+		<Fragment>
+			<RichTextToolbarButton
+				icon="editor-ul"
+				title={ __( 'Convert to unordered list', 'block-lab' ) }
+				isActive={ !! value && !! value.name && isActiveListType( value, 'ul', tagName ) }
+				onClick={ () => {
+					onChange( changeListType( value, { type: 'ul' } ) );
+
+					if ( isListRootSelected( value ) ) {
+						setAttributes( { ordered: false } );
+					}
+				} }
+			/>
+			<RichTextToolbarButton
+				icon="editor-ol"
+				title={ __( 'Convert to ordered list', 'block-lab' ) }
+				isActive={ !! value && !! value.name && isActiveListType( value, 'ol', tagName ) }
+				onClick={ () => {
+					onChange( changeListType( value, { type: 'ol' } ) );
+
+					if ( isListRootSelected( value ) ) {
+						setAttributes( { ordered: true } );
+					}
+				} }
+			/>
+		</Fragment>
+	);
+};
+
+registerFormatType(
+	listControlName,
+	{
+		title: __( 'List Type Controls', 'block-lab' ),
+		tagName,
+		className: 'bl-aligned',
+		attributes: {
+			align: 'style',
+		},
+		edit: ( { onChange, value } ) => {
+			return (
+				<ListToolbar
+					value={ value }
+					onChange={ ( newListType ) => {
+						if ( newListType ) {
+							onChange(
+								applyFormat(
+									value,
+									{
+										type: listControlName,
+										attributes: {
+											align: getListStyle( newListType ),
+										},
+									},
+								)
+							);
+						} else {
+							onChange(
+								removeFormat(
+									value,
+									{
+										type: listControlName,
+										attributes: {
+											align: getListStyle( value ),
+										},
+									},
+								)
+							);
+						}
+					} }
+				/>
+			);
+		},
+	}
+);
 
 const BlockLabRichTextControl = ( props ) => {
 	const { field, getValue, instanceId, onChange } = props;
@@ -27,7 +140,8 @@ const BlockLabRichTextControl = ( props ) => {
 				multiline={ true }
 				inlineToolbar={ true }
 				onChange={ onChange }
-			/>
+			>
+			</RichText>
 		</BaseControl>
 	);
 };

--- a/js/blocks/controls/rich-text.js
+++ b/js/blocks/controls/rich-text.js
@@ -2,11 +2,7 @@
  * WordPress dependencies
  */
 const { BaseControl } = wp.components;
-
-/**
- * Internal dependencies
- */
-import { TinyMCE } from '../components';
+const { RichText } = wp.blockEditor;
 
 const BlockLabRichTextControl = ( props ) => {
 	const { field, getValue, instanceId, onChange } = props;
@@ -18,10 +14,22 @@ const BlockLabRichTextControl = ( props ) => {
 			className="block-lab-rich-text-control"
 			help={ field.help }
 		>
-			<TinyMCE
-				content={ getValue( props ) }
+			{
+			/*
+			* @todo: Resolve known issue with toolbar not disappearing on blur
+			* @see: https://github.com/WordPress/gutenberg/issues/7463
+			*/
+			}
+			<RichText
+				key={ `block-lab-${ field.name }` }
+				placeholder={ field.placeholder || '' }
+				keepPlaceholderOnFocus={ true }
+				defaultValue={ field.default }
+				value={ getValue( props ) }
+				className="input-control"
+				multiline={ true }
+				inlineToolbar={ true }
 				onChange={ onChange }
-				editorId={ `rich-text-${ field.name }` }
 			/>
 		</BaseControl>
 	);

--- a/js/blocks/controls/rich-text.js
+++ b/js/blocks/controls/rich-text.js
@@ -21,7 +21,7 @@ const BlockLabRichTextControl = ( props ) => {
 			<TinyMCE
 				content={ getValue( props ) }
 				onChange={ onChange }
-				clientId={ `rich-text-${ field.name }` }
+				editorId={ `rich-text-${ field.name }` }
 			/>
 		</BaseControl>
 	);

--- a/js/blocks/controls/rich-text.js
+++ b/js/blocks/controls/rich-text.js
@@ -140,8 +140,7 @@ const BlockLabRichTextControl = ( props ) => {
 				multiline={ true }
 				inlineToolbar={ true }
 				onChange={ onChange }
-			>
-			</RichText>
+			/>
 		</BaseControl>
 	);
 };

--- a/php/blocks/controls/class-classic-text.php
+++ b/php/blocks/controls/class-classic-text.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Classic Text control.
+ *
+ * @package   Block_Lab
+ * @copyright Copyright(c) 2019, Block Lab
+ * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
+ */
+
+namespace Block_Lab\Blocks\Controls;
+
+/**
+ * Class Classic_Text
+ */
+class Classic_Text extends Control_Abstract {
+
+	/**
+	 * Control name.
+	 *
+	 * @var string
+	 */
+	public $name = 'classic_text';
+
+	/**
+	 * Textarea constructor.
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		parent::__construct();
+		$this->label = __( 'Classic Text', 'block-lab' );
+	}
+
+	/**
+	 * Register settings.
+	 *
+	 * @return void
+	 */
+	public function register_settings() {
+		foreach ( array( 'help', 'default' ) as $setting ) {
+			$this->settings[] = new Control_Setting( $this->settings_config[ $setting ] );
+		}
+	}
+
+	/**
+	 * Validates the value to be made available to the front-end template.
+	 *
+	 * @param mixed $value The value to either make available as a variable or echoed on the front-end template.
+	 * @param bool  $echo Whether this will be echoed.
+	 * @return mixed $value The value to be made available or echoed on the front-end template.
+	 */
+	public function validate( $value, $echo ) {
+		unset( $echo );
+		return wpautop( $value );
+	}
+}

--- a/php/blocks/controls/class-classic-text.php
+++ b/php/blocks/controls/class-classic-text.php
@@ -22,7 +22,7 @@ class Classic_Text extends Control_Abstract {
 	public $name = 'classic_text';
 
 	/**
-	 * Textarea constructor.
+	 * Class constructor.
 	 *
 	 * @return void
 	 */

--- a/php/blocks/controls/class-classic-text.php
+++ b/php/blocks/controls/class-classic-text.php
@@ -41,16 +41,4 @@ class Classic_Text extends Control_Abstract {
 			$this->settings[] = new Control_Setting( $this->settings_config[ $setting ] );
 		}
 	}
-
-	/**
-	 * Validates the value to be made available to the front-end template.
-	 *
-	 * @param mixed $value The value to either make available as a variable or echoed on the front-end template.
-	 * @param bool  $echo Whether this will be echoed.
-	 * @return mixed $value The value to be made available or echoed on the front-end template.
-	 */
-	public function validate( $value, $echo ) {
-		unset( $echo );
-		return wpautop( $value );
-	}
 }

--- a/php/blocks/controls/class-rich-text.php
+++ b/php/blocks/controls/class-rich-text.php
@@ -22,7 +22,7 @@ class Rich_Text extends Control_Abstract {
 	public $name = 'rich_text';
 
 	/**
-	 * Textarea constructor.
+	 * Class constructor.
 	 *
 	 * @return void
 	 */

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -41,8 +41,8 @@ class Block_Post extends Component_Abstract {
 	public $pro_controls = array(
 		'repeater',
 		'post',
-		'classic_text',
 		'rich_text',
+		'classic_text',
 		'taxonomy',
 		'user',
 	);

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -41,6 +41,7 @@ class Block_Post extends Component_Abstract {
 	public $pro_controls = array(
 		'repeater',
 		'post',
+		'classic_text',
 		'rich_text',
 		'taxonomy',
 		'user',

--- a/tests/php/integration/fixtures/all-fields-except-repeater.php
+++ b/tests/php/integration/fixtures/all-fields-except-repeater.php
@@ -8,7 +8,6 @@
 // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaping could interfere with testing block_value().
 
 $non_object_fields = array(
-	'text',
 	'textarea',
 	'url',
 	'email',
@@ -20,7 +19,9 @@ $non_object_fields = array(
 	'range',
 	'checkbox',
 	'radio',
+	'text',
 	'rich-text',
+	'classic-text',
 );
 
 foreach ( $non_object_fields as $field ) :

--- a/tests/php/integration/test-template-output.php
+++ b/tests/php/integration/test-template-output.php
@@ -30,6 +30,7 @@ class Test_Template_Output extends Abstract_Attribute {
 		$this->loader     = new Blocks\Loader();
 
 		$this->attributes = array(
+			'classic-text' => '<h1>Here is a heading</h1><p>This is paragraph text that is <strong>bold</strong> and <em>italic</em></p><ul><li>Here is a li</li><li>And the next</li></ul>',
 			'className'   => $this->class_name,
 			'checkbox'    => true,
 			'text'        => 'Here is a text field',
@@ -51,6 +52,7 @@ class Test_Template_Output extends Abstract_Attribute {
 		);
 
 		$this->string_fields = array(
+			'classic-text',
 			'text',
 			'textarea',
 			'url',

--- a/tests/php/unit/blocks/controls/test-class-classic-text.php
+++ b/tests/php/unit/blocks/controls/test-class-classic-text.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Tests for class Classic_Text.
+ *
+ * @package Block_Lab
+ */
+
+use Block_Lab\Blocks\Controls;
+
+/**
+ * Tests for class Classic_Text.
+ */
+class Test_Classic_Text extends \WP_UnitTestCase {
+
+	use Testing_Helper;
+
+	/**
+	 * Instance of Classic_Text.
+	 *
+	 * @var Controls\Classic_Text
+	 */
+	public $instance;
+
+	/**
+	 * Setup.
+	 *
+	 * @inheritdoc
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->instance = new Controls\Classic_Text();
+	}
+
+	/**
+	 * Test __construct.
+	 *
+	 * @covers \Block_Lab\Blocks\Controls\Classic_Text::__construct()
+	 */
+	public function test_construct() {
+		$this->assertEquals( 'Classic Text', $this->instance->label );
+		$this->assertEquals( 'classic_text', $this->instance->name );
+	}
+
+	/**
+	 * Test register_settings.
+	 *
+	 * @covers \Block_Lab\Blocks\Controls\Classic_Text::register_settings()
+	 */
+	public function test_register_settings() {
+		$expected_settings = array(
+			array(
+				'name'     => 'help',
+				'label'    => 'Help Text',
+				'type'     => 'text',
+				'default'  => '',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
+				'validate' => '',
+				'value'    => null,
+			),
+			array(
+				'name'     => 'default',
+				'label'    => 'Default Value',
+				'type'     => 'text',
+				'default'  => '',
+				'help'     => '',
+				'sanitize' => 'sanitize_text_field',
+				'validate' => '',
+				'value'    => null,
+			),
+		);
+
+		$this->assert_correct_settings( $expected_settings, $this->instance->settings );
+	}
+
+	/**
+	 * Test validate.
+	 *
+	 * @covers \Block_Lab\Blocks\Controls\Classic_Text::validate()
+	 */
+	public function test_validate() {
+		$markup_with_br_tags         = '<span>First line<br><br></span>';
+		$expected_markup_with_p_tags = "<p><span>First line</p>\n<p></span></p>\n";
+
+		// This should have the same results, whether the second $echo argument is true or false.
+		$this->assertEquals( $expected_markup_with_p_tags, $this->instance->validate( $markup_with_br_tags, true ) );
+		$this->assertEquals( $expected_markup_with_p_tags, $this->instance->validate( $markup_with_br_tags, false ) );
+	}
+}

--- a/tests/php/unit/blocks/controls/test-class-classic-text.php
+++ b/tests/php/unit/blocks/controls/test-class-classic-text.php
@@ -72,18 +72,4 @@ class Test_Classic_Text extends \WP_UnitTestCase {
 
 		$this->assert_correct_settings( $expected_settings, $this->instance->settings );
 	}
-
-	/**
-	 * Test validate.
-	 *
-	 * @covers \Block_Lab\Blocks\Controls\Classic_Text::validate()
-	 */
-	public function test_validate() {
-		$markup_with_br_tags         = '<span>First line<br><br></span>';
-		$expected_markup_with_p_tags = "<p><span>First line</p>\n<p></span></p>\n";
-
-		// This should have the same results, whether the second $echo argument is true or false.
-		$this->assertEquals( $expected_markup_with_p_tags, $this->instance->validate( $markup_with_br_tags, true ) );
-		$this->assertEquals( $expected_markup_with_p_tags, $this->instance->validate( $markup_with_br_tags, false ) );
-	}
 }

--- a/tests/php/unit/helpers/trait-testing-helper.php
+++ b/tests/php/unit/helpers/trait-testing-helper.php
@@ -42,7 +42,7 @@ trait Testing_Helper {
 		if ( $is_valid ) {
 			$transient_value = array(
 				'license' => 'valid',
-				'expires' => date( '+1 month' ),
+				'expires' => date( 'D, d M Y H:i:s', time() + 1000 ),
 			);
 		} else {
 			$transient_value = array(


### PR DESCRIPTION
### Update: this has changed, please see this [comment below](https://github.com/getblocklab/block-lab/pull/432#issuecomment-538701506).
* This begins to add list buttons to the Rich Text controls
* Still, it might not be possible to get this to work as we'd expect. For example, it looks like it's not possible to have the list buttons next to the bold and italic buttons:

<img width="679" alt="rich-text-control" src="https://user-images.githubusercontent.com/4063887/65123699-6cdb4f80-d9b9-11e9-8ea7-8174f6f34b19.png">

Also, it might be really hard to make only part of the text a list.

For example, in the Core List block, it simply makes its entire `<RichText>` component a `<ul>` or `<ol>`. I'm not sure if the `<RichText>` has a good way to make only part of the text into a `<ul>` or `<ol>`.

Closes #405 (if this works)