### PR TITLE
Add a few tests, including for Loader

### DIFF
--- a/js/blocks/loader/attributes.js
+++ b/js/blocks/loader/attributes.js
@@ -1,7 +1,7 @@
 /**
  * Gets the attributes for a block, based on given fields.
  *
- * @param {Object} fields     The fields to get the attributes from.
+ * @param {Object} fields The fields to get the attributes from.
  * @return {Object} attributes The attributes for the fields.
  */
 const getBlockAttributes = ( fields ) => {

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -338,7 +338,7 @@ class Block_Post extends Component_Abstract {
 			'default'
 		);
 
-		if ( isset( $post->post_name ) && ! empty( $post->post_name ) ) {
+		if ( ! empty( $post->post_name ) ) {
 			$locations = block_lab()->get_template_locations( $post->post_name );
 			$template  = block_lab()->locate_template( $locations, '', true );
 

--- a/tests/php/integration/fixtures/repeater-all-fields.php
+++ b/tests/php/integration/fixtures/repeater-all-fields.php
@@ -33,7 +33,7 @@ if ( block_rows( $repeater_name ) ) :
 	while ( block_rows( $repeater_name ) ) :
 		block_row( $repeater_name );
 			printf(
-				'In row %d, the result of block_row_index() is %s: ',
+				'In row %d, the result of block_row_index() is %d',
 				$row_number,
 				block_row_index()
 			);

--- a/tests/php/integration/fixtures/repeater-all-fields.php
+++ b/tests/php/integration/fixtures/repeater-all-fields.php
@@ -29,8 +29,14 @@ $non_object_fields = array(
 <?php
 if ( block_rows( $repeater_name ) ) :
 	$row_number = 0;
+	printf( 'block_row_count() returns %d', block_row_count( $repeater_name ) );
 	while ( block_rows( $repeater_name ) ) :
 		block_row( $repeater_name );
+			printf(
+				'In row %d, the result of block_row_index() is %s: ',
+				$row_number,
+				block_row_index()
+			);
 
 		foreach ( $non_object_fields as $field ) :
 			?>

--- a/tests/php/integration/test-repeater-template-output.php
+++ b/tests/php/integration/test-repeater-template-output.php
@@ -215,7 +215,7 @@ class Test_Repeater_Template_Output extends Abstract_Attribute {
 		foreach ( $rows as $row_number => $row ) {
 			$this->assertContains(
 				sprintf(
-					'In row %d, the result of block_row_index() is %s: ',
+					'In row %d, the result of block_row_index() is %d',
 					$row_number,
 					$row_number
 				),

--- a/tests/php/integration/test-repeater-template-output.php
+++ b/tests/php/integration/test-repeater-template-output.php
@@ -181,6 +181,14 @@ class Test_Repeater_Template_Output extends Abstract_Attribute {
 	 * This has a repeater with 2 rows, and tests every possible field.
 	 * It sets mock block attributes, like those that would be saved from a block.
 	 * Then, it loads the mock template in the theme's blocks/ directory and asserts the values.
+	 *
+	 * @covers \block_rows()
+	 * @covers \block_row()
+	 * @covers \reset_block_row()
+	 * @covers \block_row_field()
+	 * @covers \block_row_value()
+	 * @covers \block_row_index()
+	 * @covers \block_row_count()
 	 */
 	public function test_repeater_template() {
 		$block = new Blocks\Block();

--- a/tests/php/integration/test-repeater-template-output.php
+++ b/tests/php/integration/test-repeater-template-output.php
@@ -189,11 +189,31 @@ class Test_Repeater_Template_Output extends Abstract_Attribute {
 		$actual_template   = str_replace( array( "\t", "\n" ), '', $rendered_template );
 		$rows              = $this->attributes[ self::REPEATER_FIELD_NAME ]['rows'];
 
+		$this->assertContains(
+			sprintf(
+				'block_row_count() returns %d',
+				count( $rows )
+			),
+			$actual_template
+		);
+
 		// The 'className' should be present.
 		$this->assertContains(
 			sprintf( '<div class="%s">', $this->class_name ),
 			$actual_template
 		);
+
+		// Test that block_row_index() returns the right row index.
+		foreach ( $rows as $row_number => $row ) {
+			$this->assertContains(
+				sprintf(
+					'In row %d, the result of block_row_index() is %s: ',
+					$row_number,
+					$row_number
+				),
+				$actual_template
+			);
+		}
 
 		// Test the fields that return a string for block_sub_value().
 		foreach ( $rows as $row_number => $row ) {

--- a/tests/php/integration/test-template-output.php
+++ b/tests/php/integration/test-template-output.php
@@ -139,6 +139,9 @@ class Test_Template_Output extends Abstract_Attribute {
 	 * This sets mock block attributes, like those that would be saved from a block.
 	 * Then, it loads the mock template in the theme's blocks/ directory,
 	 * and ensures that all of these fields appear correctly in it.
+	 *
+	 * @covers \block_field()
+	 * @covers \block_value()
 	 */
 	public function test_block_template() {
 		$block = new Blocks\Block();

--- a/tests/php/unit/blocks/test-class-loader.php
+++ b/tests/php/unit/blocks/test-class-loader.php
@@ -20,6 +20,19 @@ class Test_Loader extends Abstract_Template {
 	public $instance;
 
 	/**
+	 * Test init.
+	 *
+	 * @covers \Block_Lab\Blocks\Loader::init()
+	 */
+	public function test_init() {
+		$this->assertEquals( 'Block_Lab\\Blocks\\Loader', get_class( $this->instance->init() ) );
+		$this->assertContains( 'js/editor.blocks.js', $this->instance->assets['path']['entry'] );
+		$this->assertContains( 'css/blocks.editor.css', $this->instance->assets['path']['editor_style'] );
+		$this->assertContains( 'js/editor.blocks.js', $this->instance->assets['url']['entry'] );
+		$this->assertContains( 'css/blocks.editor.css', $this->instance->assets['url']['editor_style'] );
+	}
+
+	/**
 	 * Test register_hooks.
 	 *
 	 * @covers \Block_Lab\Blocks\Loader::register_hooks()


### PR DESCRIPTION
* This adds tests for random parts of the plugin, including `Loader` and some of the new repeater helper functions
* Unit tests for the repeater functions probably wouldn't help, as they're mainly wrappers for other logic