### PR TITLE
Experiment with moving Loader class into a property of Plugin, making most methods protected

### DIFF
--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -29,6 +29,13 @@ class Plugin extends Plugin_Abstract {
 	public $admin;
 
 	/**
+	 * Block loader.
+	 *
+	 * @var Blocks\Loader
+	 */
+	public $loader;
+
+	/**
 	 * The slug of the post type that stores the blocks.
 	 *
 	 * @since 1.3.5
@@ -42,9 +49,10 @@ class Plugin extends Plugin_Abstract {
 	public function init() {
 		$this->util = new Util();
 		$this->register_component( $this->util );
-
 		$this->register_component( new Post_Types\Block_Post() );
-		$this->register_component( new Blocks\Loader() );
+
+		$this->loader = new Blocks\Loader();
+		$this->register_component( $this->loader );
 
 		register_activation_hook(
 			$this->get_file(),

--- a/tests/php/integration/helpers/class-abstract-attribute.php
+++ b/tests/php/integration/helpers/class-abstract-attribute.php
@@ -120,6 +120,21 @@ abstract class Abstract_Attribute extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Invokes a protected method.
+	 *
+	 * @param object $instance The instance to invoke the method on.
+	 * @param string $method_name The name of the method.
+	 * @param array  $args The arguments.
+	 * @return mixed The result of invoking the method.
+	 * @throws ReflectionException If invoking this fails.
+	 */
+	public function invoke_protected_method( $instance, $method_name, $args = array() ) {
+		$method = new ReflectionMethod( $instance, $method_name );
+		$method->setAccessible( true );
+		return $method->invokeArgs( $instance, $args );
+	}
+
+	/**
 	 * Sets class properties.
 	 */
 	public function set_properties() {}

--- a/tests/php/integration/test-defaults.php
+++ b/tests/php/integration/test-defaults.php
@@ -137,7 +137,7 @@ class Test_Defaults extends Abstract_Attribute {
 	public function test_block_template() {
 		$block = new Blocks\Block();
 		$block->from_array( $this->get_block_config() );
-		$rendered_template = $this->loader->render_block_template( $block, $this->attributes );
+		$rendered_template = $this->invoke_protected_method( $this->loader, 'render_block_template', array( $block, $this->attributes ) );
 		$actual_template   = str_replace( array( "\t", "\n" ), '', $rendered_template );
 
 		// The 'className' should be present.

--- a/tests/php/integration/test-repeater-template-output.php
+++ b/tests/php/integration/test-repeater-template-output.php
@@ -193,7 +193,7 @@ class Test_Repeater_Template_Output extends Abstract_Attribute {
 	public function test_repeater_template() {
 		$block = new Blocks\Block();
 		$block->from_array( $this->get_block_config() );
-		$rendered_template = $this->loader->render_block_template( $block, $this->attributes );
+		$rendered_template = $this->invoke_protected_method( $this->loader, 'render_block_template', array( $block, $this->attributes ) );
 		$actual_template   = str_replace( array( "\t", "\n" ), '', $rendered_template );
 		$rows              = $this->attributes[ self::REPEATER_FIELD_NAME ]['rows'];
 

--- a/tests/php/integration/test-template-output.php
+++ b/tests/php/integration/test-template-output.php
@@ -146,7 +146,7 @@ class Test_Template_Output extends Abstract_Attribute {
 	public function test_block_template() {
 		$block = new Blocks\Block();
 		$block->from_array( $this->get_block_config() );
-		$rendered_template = $this->loader->render_block_template( $block, $this->attributes );
+		$rendered_template = $this->invoke_protected_method( $this->loader, 'render_block_template', array( $block, $this->attributes ) );
 		$actual_template   = str_replace( array( "\t", "\n" ), '', $rendered_template );
 
 		// The 'className' should be present.

--- a/tests/php/unit/helpers/class-abstract-template.php
+++ b/tests/php/unit/helpers/class-abstract-template.php
@@ -48,7 +48,7 @@ abstract class Abstract_Template extends \WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->instance = new Blocks\Loader();
-		$this->instance->set_plugin( block_lab() );
+		$this->invoke_protected_method( 'set_plugin', array( block_lab() ) );
 
 		$this->theme_directory    = get_template_directory();
 		$this->template_locations = block_lab()->get_template_locations( $this->mock_block_name );
@@ -85,6 +85,34 @@ abstract class Abstract_Template extends \WP_UnitTestCase {
 		);
 
 		parent::tearDown();
+	}
+
+	/**
+	 * Invokes a protected method.
+	 *
+	 * @param string $method_name The name of the method.
+	 * @param array  $args The arguments.
+	 * @return mixed The result of invoking the method.
+	 * @throws ReflectionException If invoking this fails.
+	 */
+	public function invoke_protected_method( $method_name, $args = array() ) {
+		$method = new ReflectionMethod( $this->instance, $method_name );
+		$method->setAccessible( true );
+		return $method->invokeArgs( $this->instance, $args );
+	}
+
+	/**
+	 * Gets a protected property's value.
+	 *
+	 * @param string $property The name of the property to get.
+	 * @return mixed The property value
+	 * @throws ReflectionException For a non-accessible property.
+	 */
+	public function get_protected_property( $property ) {
+		$reflection = new \ReflectionObject( $this->instance );
+		$property   = $reflection->getProperty( $property );
+		$property->setAccessible( true );
+		return $property->getValue( $this->instance );
 	}
 
 	/**


### PR DESCRIPTION
* This should allow easier access to `Loader`
* `Loader` is a dependency of other files, like `helpers.php`, which uses the (recently changed) globals `$block_lab_attributes` and `$block_lab_config`
* This allows adding public methods to `Loader` that other classes can access, like `block_lab()->loader->add_block()`
* Most methods of `Loader` are now `protected`

Related to #434, #435