### PR TITLE
Prevent `</p>` output in Rich Text control

### DIFF
--- a/php/blocks/controls/class-rich-text.php
+++ b/php/blocks/controls/class-rich-text.php
@@ -51,6 +51,12 @@ class Rich_Text extends Control_Abstract {
 	 */
 	public function validate( $value, $echo ) {
 		unset( $echo );
+
+		// For this value, wpautop() returns '</p>', so simply return the value.
+		if ( '<p></p>' === $value ) {
+			return $value;
+		}
+
 		return wpautop( $value );
 	}
 }

--- a/php/blocks/controls/class-rich-text.php
+++ b/php/blocks/controls/class-rich-text.php
@@ -52,9 +52,9 @@ class Rich_Text extends Control_Abstract {
 	public function validate( $value, $echo ) {
 		unset( $echo );
 
-		// For this value, wpautop() returns '</p>', so simply return the value.
+		// If there's no text entered, Rich Text saves '<p></p>', so instead return ''.
 		if ( '<p></p>' === $value ) {
-			return $value;
+			return '';
 		}
 
 		return wpautop( $value );

--- a/tests/php/unit/blocks/controls/test-class-rich-text.php
+++ b/tests/php/unit/blocks/controls/test-class-rich-text.php
@@ -95,5 +95,8 @@ class Test_Rich_Text extends \WP_UnitTestCase {
 		// This should have the same results, whether the second $echo argument is true or false.
 		$this->assertEquals( $expected_markup_with_p_tags, $this->instance->validate( $markup_with_br_tags, true ) );
 		$this->assertEquals( $expected_markup_with_p_tags, $this->instance->validate( $markup_with_br_tags, false ) );
+
+		$empty_paragraph = '<p></p>';
+		$this->assertEquals( $empty_paragraph, $this->instance->validate( $empty_paragraph, false ) );
 	}
 }

--- a/tests/php/unit/blocks/controls/test-class-rich-text.php
+++ b/tests/php/unit/blocks/controls/test-class-rich-text.php
@@ -97,6 +97,6 @@ class Test_Rich_Text extends \WP_UnitTestCase {
 		$this->assertEquals( $expected_markup_with_p_tags, $this->instance->validate( $markup_with_br_tags, false ) );
 
 		$empty_paragraph = '<p></p>';
-		$this->assertEquals( $empty_paragraph, $this->instance->validate( $empty_paragraph, false ) );
+		$this->assertEquals( '', $this->instance->validate( $empty_paragraph, false ) );
 	}
 }

--- a/tests/php/unit/helpers/trait-testing-helper.php
+++ b/tests/php/unit/helpers/trait-testing-helper.php
@@ -42,7 +42,7 @@ trait Testing_Helper {
 		if ( $is_valid ) {
 			$transient_value = array(
 				'license' => 'valid',
-				'expires' => date( '+1 month' ),
+				'expires' => date( 'D, d M Y H:i:s', time() + 1000 ),
 			);
 		} else {
 			$transient_value = array(


### PR DESCRIPTION
## Steps to reproduce
1. Create a new post
2. Add a Block Lab block that has a Rich Text field without a default value
3. Don't enter any text in the Rich Text field
4. Publish the post, and go to the front-end
5. Expected: The output is well-formed html
6. Actual: The output is `</p>`, as reported in #437:

<img width="528" alt="closing-p" src="https://user-images.githubusercontent.com/4063887/66259261-7f54d780-e774-11e9-8c71-8a0ccaac91fe.png">

It looks like when the <RichText> component has no text, it saves `<p></p>`. But passing that to wpautop() returns `</p>`:

<img width="982" alt="wpautop-here" src="https://user-images.githubusercontent.com/4063887/66259292-d9559d00-e774-11e9-91b0-2d6385195320.png">

So in that case, this PR simply returns the string.

Closes #437