### PR TITLE
Fix an issue where the Color control didn't save the updated value

### DIFF
--- a/js/blocks/controls/color.js
+++ b/js/blocks/controls/color.js
@@ -12,7 +12,7 @@ const BlockLabColorPopover = withState( {
 			newColor = 'rgba(' + value.rgb.r + ', ' + value.rgb.g + ', ' + value.rgb.b + ', ' + value.rgb.a + ')';
 		}
 		setState( () => ( { color: newColor } ) );
-		onUpdate( { color: newColor } );
+		onUpdate( newColor );
 	};
 
 	return (


### PR DESCRIPTION
I introduced this regression with https://github.com/getblocklab/block-lab/commit/64608778ff38b17494f36519ba6a3abb1ad52bb5#diff-8560414ca7fa9bc14e3a53f56c811d44R15

It looks like `onUpdate()` should only accept the string color, not an object, as it currently has.

<img width="653" alt="hex-here" src="https://user-images.githubusercontent.com/4063887/67650962-8fd81800-f904-11e9-9a75-f638e4749e55.png">


Fixes #452 