### PR TITLE
Fix rich text toolbar styles

### DIFF
--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -421,7 +421,7 @@ div[class^="wp-block-block-lab-"] {
 
 /* Miscellaneous global styles */
 .edit-post-layout {
-  .components-popover:not(.is-mobile):not(.bl-fetch__popover) .components-popover__content {
+  .components-popover:not(.is-mobile):not(.bl-fetch__popover) .components-popover__content .components-color-picker {
     min-width: 340px;
   }
 }


### PR DESCRIPTION
Fixes a regression with the toolbar styles for the Rich Text field.

Before:
![Screen Shot 2019-10-28 at 2 04 43 pm](https://user-images.githubusercontent.com/1097667/67651566-5eeff580-f98d-11e9-8071-b0a4dce17968.png)

After:
![Screen Shot 2019-10-28 at 2 14 38 pm](https://user-images.githubusercontent.com/1097667/67651570-644d4000-f98d-11e9-9e3b-1db1df7aac3e.png)
