### PR TITLE
Bugfix for the PHP API – allow themes to hook in via the functions.php file

### DIFF
--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -54,8 +54,6 @@ class Loader extends Component_Abstract {
 			],
 		];
 
-		$this->retrieve_blocks();
-
 		return $this;
 	}
 
@@ -74,9 +72,14 @@ class Loader extends Component_Abstract {
 		add_filter( 'block_categories', $this->get_callback( 'register_categories' ) );
 
 		/**
+		 * Block retrieval.
+		 */
+		add_action( 'init', $this->get_callback( 'retrieve_blocks' ), 1 );
+
+		/**
 		 * PHP block loading.
 		 */
-		add_action( 'plugins_loaded', $this->get_callback( 'dynamic_block_loader' ) );
+		add_action( 'init', $this->get_callback( 'dynamic_block_loader' ) );
 	}
 
 	/**
@@ -606,7 +609,7 @@ class Loader extends Component_Abstract {
 	 * that the block isn't added too late.
 	 *
 	 * @param string $block_name The name of the block that the field is added to.
-	 * @param array $field_config The config of the field to add.
+	 * @param array  $field_config The config of the field to add.
 	 */
 	public function add_field( $block_name, $field_config ) {
 		if ( ! isset( $this->blocks[ "block-lab/{$block_name}" ] ) ) {


### PR DESCRIPTION
In my testing of the PHP API I was always just using code that I threw into a quick little plugin.

Just now, I tried registering a block using the PHP API via the `functions.php` file that is loaded with the theme… and **it didn't work**!

This is because the action was firing before the theme was ready.

This PR fixes that by retrieving the blocks a little later (during `init`), which also requires that we load the blocks a little later (moved from `plugins_ready` to `init`).

I have tested fairly extensively (previous blocks still work, new blocks work, blocks are loaded from a JSON file and work, blocks can be registered via the PHP API through a theme, blocks load in the editor, blocks load on the frontend).

That said, this is a small change that could have a large impact. Please test thoroughly!