### PR TITLE
Fix an issue with Classic Text fields in a repeater

### DIFF
--- a/js/blocks/components/fields.js
+++ b/js/blocks/components/fields.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 const { applyFilters } = wp.hooks;
+const { select } = wp.data;
 
 /**
  * Internal dependencies
@@ -59,14 +60,15 @@ const Fields = ( { fields, parentBlockProps, parentBlock, rowIndex } ) => {
 		 * the block's setAttributes property, so that the block can save the value.
 		 * This function is passed to the control so that the control can save the value,
 		 * depending on whether the control is in a repeater row or not.
+		 * This gets the latest parentAttributes by using select( 'core/block-editor' ),
+		 * as the parentBlockProps.attributes in the outer scope may be outdated.
 		 *
 		 * @param {*} newValue The new control value.
 		 */
 		const onChange = ( newValue ) => {
-			const attr = { ...parentBlockProps.attributes };
-			const attribute = attr[ field.parent ];
-			const { setAttributes } = parentBlockProps;
-			const defaultRows = [ {} ];
+			const { clientId, setAttributes } = parentBlockProps;
+			const parentAttributes = select( 'core/block-editor' ).getBlockAttributes( clientId );
+			const attr = { ...parentAttributes };
 
 			if ( undefined === rowIndex ) {
 				// This is not in a repeater row.
@@ -74,18 +76,15 @@ const Fields = ( { fields, parentBlockProps, parentBlock, rowIndex } ) => {
 				setAttributes( attr );
 			} else {
 				// This is in a repeater row.
+				const attribute = attr[ field.parent ];
+				const defaultRows = [ {} ];
 				const rows = ( attribute && attribute.rows ) ? attribute.rows : defaultRows;
 
-				/*
-				 * Copy the rows array, so the change is recognized.
-				 * @see https://github.com/WordPress/gutenberg/issues/7016#issuecomment-396094836
-				 */
-				const rowsCopy = rows.slice();
-				if ( ! rowsCopy[ rowIndex ] ) {
-					rowsCopy[ rowIndex ] = {};
+				if ( ! rows[ rowIndex ] ) {
+					rows[ rowIndex ] = {};
 				}
-				rowsCopy[ rowIndex ][ field.name ] = newValue;
-				attr[ field.parent ] = { rows: rowsCopy };
+				rows[ rowIndex ][ field.name ] = newValue;
+				attr[ field.parent ] = { rows };
 				parentBlockProps.setAttributes( attr );
 			}
 		};

--- a/js/blocks/components/fields.js
+++ b/js/blocks/components/fields.js
@@ -118,9 +118,8 @@ const Fields = ( { fields, parentBlockProps, parentBlock, rowIndex } ) => {
 		const Control = getControl( field );
 
 		return !! Control && (
-			<div className={ getClassName( field ) }>
+			<div className={ getClassName( field ) } key={ `${ field.name }-control-${ rowIndex }` }>
 				<Control
-					key={ `${ field.name }-control-${ rowIndex }` }
 					field={ field }
 					getValue={ getValue }
 					onChange={ onChange }

--- a/js/blocks/controls/classic-text.js
+++ b/js/blocks/controls/classic-text.js
@@ -10,7 +10,7 @@ import { TinyMCE } from '../components';
 
 const BlockLabClassicTextControl = ( props ) => {
 	const { field, getValue, instanceId, onChange, rowIndex } = props;
-	const editorId = rowIndex ? `bl-classic-text-${ field.name }-${ rowIndex }` : `bl-classic-text-${ field.name }`;
+	const editorId = 'number' === typeof rowIndex ? `bl-classic-text-${ field.name }-${ rowIndex }` : `bl-classic-text-${ field.name }`;
 
 	return (
 		<BaseControl

--- a/js/blocks/controls/classic-text.js
+++ b/js/blocks/controls/classic-text.js
@@ -9,8 +9,9 @@ const { BaseControl } = wp.components;
 import { TinyMCE } from '../components';
 
 const BlockLabClassicTextControl = ( props ) => {
-	const { field, getValue, instanceId, onChange, rowIndex } = props;
-	const editorId = 'number' === typeof rowIndex ? `bl-classic-text-${ field.name }-${ rowIndex }` : `bl-classic-text-${ field.name }`;
+	const { field, getValue, instanceId, onChange, parentBlockProps, rowIndex } = props;
+	const { clientId } = parentBlockProps;
+	const editorId = 'number' === typeof rowIndex ? `bl-${ clientId }-${ field.name }-rowIndex-${ rowIndex }` : `bl-${ clientId }-${ field.name }`;
 	const initialValue = getValue( props );
 	const value = 'undefined' !== typeof initialValue ? initialValue : field.default;
 

--- a/js/blocks/controls/classic-text.js
+++ b/js/blocks/controls/classic-text.js
@@ -11,6 +11,8 @@ import { TinyMCE } from '../components';
 const BlockLabClassicTextControl = ( props ) => {
 	const { field, getValue, instanceId, onChange, rowIndex } = props;
 	const editorId = 'number' === typeof rowIndex ? `bl-classic-text-${ field.name }-${ rowIndex }` : `bl-classic-text-${ field.name }`;
+	const initialValue = getValue( props );
+	const value = 'undefined' !== typeof initialValue ? initialValue : field.default;
 
 	return (
 		<BaseControl
@@ -20,7 +22,7 @@ const BlockLabClassicTextControl = ( props ) => {
 			help={ field.help }
 		>
 			<TinyMCE
-				content={ getValue( props ) }
+				content={ value }
 				onChange={ onChange }
 				editorId={ editorId }
 			/>

--- a/js/blocks/controls/classic-text.js
+++ b/js/blocks/controls/classic-text.js
@@ -9,7 +9,8 @@ const { BaseControl } = wp.components;
 import { TinyMCE } from '../components';
 
 const BlockLabClassicTextControl = ( props ) => {
-	const { field, getValue, instanceId, onChange } = props;
+	const { field, getValue, instanceId, onChange, rowIndex } = props;
+	const editorId = rowIndex ? `bl-classic-text-${ field.name }-${ rowIndex }` : `bl-classic-text-${ field.name }`;
 
 	return (
 		<BaseControl
@@ -21,7 +22,7 @@ const BlockLabClassicTextControl = ( props ) => {
 			<TinyMCE
 				content={ getValue( props ) }
 				onChange={ onChange }
-				editorId={ `classic-text-${ field.name }` }
+				editorId={ editorId }
 			/>
 		</BaseControl>
 	);


### PR DESCRIPTION
As Rob [pointed out](https://github.com/getblocklab/block-lab/issues/465#issue-515808255), only the 1st Classic Text field in a repeater works.

This looks to be because all Classic Text controls in the same Repeater were using the same `editorId`. So this creates an `editorId` that's aware of the `rowIndex`.

### Steps to reproduce

1. In the Block Lab 'Edit Block' UI, add a Repeater control to a block, and add a Classic Text control to that
2. Create a new post, and add that block
3. The Classic Text control should work fine
4. Add another row to the Repeater
5. Expected: The Classic Text control in that 2nd row should work
6: Actual: It's not possible to edit that Classic Text control

Fixes #465 