### PR TITLE
Fixes for WP 5.3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Contributors: lukecarbis, ryankienstra, Stino11, rheinardkorf
 Tags: Gutenberg, Blocks
 Requires at least: 5.0
-Tested up to: 5.2
+Tested up to: 5.3
 Requires PHP: 5.6
 Stable tag: trunk
 License: GPLv2 or later

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -158,6 +158,7 @@ div[class^="wp-block-block-lab-"] {
       margin: 1em 0 0;
 
       .components-base-control__label {
+        display: block;
         font-weight: 600;
       }
     }
@@ -167,11 +168,11 @@ div[class^="wp-block-block-lab-"] {
       font-size: 1em;
       color: rgba(0, 0, 0, 0.8);
     }
-  }
 
-  /* FetchInput component */
-  .bl-fetch-input {
-    max-width: $input-width;
+    /* Override a max-width: 25rem style rule in Core that can prevent displaying at the selected with, like 75% */
+    .components-select-control__input {
+      max-width: unset;
+    }
   }
 
   /* Rich Text Control Component */

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -418,6 +418,10 @@ div[class^="wp-block-block-lab-"] {
     }
   }
 
+  .block-lab-color-control .components-base-control__label {
+    display: block;
+  }
+
   /* The FetchInput component */
   .bl-fetch--input input[type="text"] {
     width: 100%;

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -4,6 +4,7 @@ $input-padding: 8px;
 $input-width: 300px;
 $default-font-size: 13px;
 $break-small: 600px;
+$font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 
 @mixin break-small() {
 	@media (min-width: #{ ($break-small) }) {
@@ -85,6 +86,10 @@ div[class^="wp-block-block-lab-"],
       position: relative;
     }
 
+    .bl-image__placeholder .components-button.is-button {
+      white-space: normal;
+    }
+
     .components-form-file-upload,
     .components-media-library-button,
     .bl-image__remove {
@@ -129,6 +134,7 @@ div[class^="wp-block-block-lab-"] {
 
     p {
       font-size: 1rem;
+      font-family: $font-family;
     }
 
     .block-lab-control {
@@ -152,6 +158,10 @@ div[class^="wp-block-block-lab-"] {
       .block-lab-control.width-75 {
         flex-basis: 100%;
       }
+    }
+
+    .components-base-control {
+      font-family: $font-family;
     }
 
     .components-base-control__field {

--- a/css/src/editor.scss
+++ b/css/src/editor.scss
@@ -177,6 +177,10 @@ div[class^="wp-block-block-lab-"] {
 
   /* Rich Text Control Component */
   .block-lab-rich-text-control {
+    .components-base-control__field {
+      margin-top: 20px;
+    }
+
     .input-control {
       background: #fff;
       min-height: 7em;


### PR DESCRIPTION
Fixes for WP Core 5.3 compatibility

The block editor in WP Core 5.3-RC3 now looks good, other than the points below.

I tested that all of the controls look good with WP 5.3-RC3, and display their entered values in the `<ServerSideRender>`:

* In the main editor
* In the Inspector Controls 
* In a repeater
* With all 25%, 50%, 75%, and 100% width

I didn't see an issue, other than those mentioned below. Though of course this could use more testing.

This also fixes #460 
This also fixes #459 