### PR TITLE
Feature/remove onboarding help prompt after adding first block

### DIFF
--- a/php/admin/class-onboarding.php
+++ b/php/admin/class-onboarding.php
@@ -89,7 +89,7 @@ class Onboarding extends Component_Abstract {
 		/*
 		 * On the edit post screen, editing the draft Example Block.
 		 */
-		if ( $slug === $screen->id && 'post' === $screen->base ) {
+		if ( $slug === $screen->id && 'post' === $screen->base && $post_id === $example_post_id ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			add_action( 'edit_form_advanced', array( $this, 'show_add_fields_notice' ) );
 			add_action( 'edit_form_before_permalink', array( $this, 'show_publish_notice' ) );
@@ -208,7 +208,7 @@ class Onboarding extends Component_Abstract {
 		/*
 		 * We add 4 fields to our Example Block in add_dummy_data().
 		 */
-		if ( count( $block->fields ) >= 1 ) {
+		if ( count( $block->fields ) > 4 ) {
 			return;
 		}
 		?>
@@ -228,7 +228,7 @@ class Onboarding extends Component_Abstract {
 		/**
 		 * We add 4 fields to our Example Block in add_dummy_data().
 		 */
-		if ( count( $block->fields ) >= 1 ) {
+		if ( count( $block->fields ) > 4 ) {
 			return;
 		}
 		?>

--- a/php/admin/class-onboarding.php
+++ b/php/admin/class-onboarding.php
@@ -208,7 +208,7 @@ class Onboarding extends Component_Abstract {
 		/*
 		 * We add 4 fields to our Example Block in add_dummy_data().
 		 */
-		if ( count( $block->fields ) > 4 ) {
+		if ( count( $block->fields ) >= 1 ) {
 			return;
 		}
 		?>
@@ -228,7 +228,7 @@ class Onboarding extends Component_Abstract {
 		/**
 		 * We add 4 fields to our Example Block in add_dummy_data().
 		 */
-		if ( count( $block->fields ) > 4 ) {
+		if ( count( $block->fields ) >= 1 ) {
 			return;
 		}
 		?>

--- a/php/admin/class-onboarding.php
+++ b/php/admin/class-onboarding.php
@@ -145,8 +145,8 @@ class Onboarding extends Component_Abstract {
 			<?php
 			edit_post_link(
 				__( 'Let\'s get started!', 'block-lab' ),
-				'',
-				'',
+				'<p>',
+				'</p>',
 				$example_post_id,
 				'button button--white button_cta'
 			);


### PR DESCRIPTION
I found the issue affecting everything which was that a conditional statement was missing that made the example or 'tutorial' message appear on every block that was created. I fixed this by adding the condition that it must ONLY show on on the example block. This fixed all issues and now the location message shows correctly as well on each block even if the example block 'tutorial' wasn't followed and/or not deleted.

Fixes #464