### PR TITLE
Version bump 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Changelog #
 
+### 1.5.1 – 2019-11-11 ###
+
+This is a bugfix release, focused mostly on compatibility with WordPress 5.3.
+
+* Fix: Themes can now hook into the `block_lab_add_blocks` action from the `functions.php` file
+* Fix: Classic Text fields now function as expected when inside a repeater
+* Fix: Rare instances of a `NaN` error when duplicating fields
+* Fix: Style fixes for the Block Editor in WordPress 5.3
+
 ### 1.5.0 – 2019-10-30 ###
 
 Ready for a big release? We're really happy to be introducing quite a number of highly requested features, including a PHP API for registering blocks with code, a new text field with lists and headings, and some neat workflow efficiencies when building your block. 

--- a/block-lab.php
+++ b/block-lab.php
@@ -9,7 +9,7 @@
  * Plugin Name: Block Lab
  * Plugin URI: https://getblocklab.com
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.5.0
+ * Version: 1.5.1
  * Author: Block Lab
  * Author URI: https://getblocklab.com
  * License: GPL2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "block-lab",
   "title": "Block Lab",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "homepage": "https://getblocklab.com",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a bugfix release, focused mostly on compatibility with WordPress 5.3.

* Fix: Themes can now hook into the `block_lab_add_blocks` action from the `functions.php` file
* Fix: Classic Text fields now function as expected when inside a repeater
* Fix: Rare instances of a `NaN` error when duplicating fields
* Fix: Style fixes for the Block Editor in WordPress 5.3
