### PR TITLE
Add a `<p>` about where the JSON file should come from

### DIFF
--- a/php/admin/class-import.php
+++ b/php/admin/class-import.php
@@ -96,8 +96,8 @@ class Import extends Component_Abstract {
 			<?php
 			echo wp_kses(
 				sprintf(
-					/* translators: %1$s: an opening anchor tag, %2$s: a closing anchor tag, %3$s: a different opening anchor tag, %4$s: a closing anchor tag */
-					__( 'This JSON file should come from the export link or bulk action in the %1$sContent Blocks screen%2$s, not from the main %3$sExport tool%4$s.', 'block-lab' ),
+					/* translators: %1$s: an opening anchor tag, %2$s: a closing anchor tag */
+					__( 'This JSON file should come from the export link or bulk action in the %1$sContent Blocks screen%2$s, not from the main Export tool.', 'block-lab' ),
 					sprintf(
 						'<a href="%1$s">',
 						esc_url(
@@ -108,11 +108,6 @@ class Import extends Component_Abstract {
 								)
 							)
 						)
-					),
-					'</a>',
-					sprintf(
-						'<a href="%1$s">',
-						esc_url( admin_url( 'export.php' ) )
 					),
 					'</a>'
 				),

--- a/php/admin/class-import.php
+++ b/php/admin/class-import.php
@@ -92,6 +92,37 @@ class Import extends Component_Abstract {
 		?>
 		<p><?php esc_html_e( 'Welcome! This importer processes Block Lab JSON files, adding custom blocks to this site.', 'block-lab' ); ?></p>
 		<p><?php esc_html_e( 'Choose a JSON (.json) file to upload, then click Upload file and import.', 'block-lab' ); ?></p>
+		<p>
+			<?php
+			echo wp_kses(
+				sprintf(
+					/* translators: %1$s: an opening anchor tag, %2$s: a closing anchor tag, %3$s: a different opening anchor tag, %4$s: a closing anchor tag */
+					__( 'This JSON file should come from the export link or bulk action in the %1$sContent Blocks screen%2$s, not from the main %3$sExport tool%4$s.', 'block-lab' ),
+					sprintf(
+						'<a href="%1$s">',
+						esc_url(
+							admin_url(
+								add_query_arg(
+									array( 'post_type' => block_lab()->get_post_type_slug() ),
+									'edit.php'
+								)
+							)
+						)
+					),
+					'</a>',
+					sprintf(
+						'<a href="%1$s">',
+						esc_url( admin_url( 'export.php' ) )
+					),
+					'</a>'
+				),
+				array(
+					'a' => array( 'href' => array() )
+				)
+			);
+			?>
+		</p>
+
 		<?php
 		wp_import_upload_form(
 			add_query_arg(

--- a/tests/php/unit/admin/test-class-import.php
+++ b/tests/php/unit/admin/test-class-import.php
@@ -285,6 +285,7 @@ class Test_Import extends \WP_UnitTestCase {
 
 		$this->assertContains( '<p>Welcome! This importer processes Block Lab JSON files, adding custom blocks to this site.</p>', $output );
 		$this->assertContains( '<label for="upload">Choose a file from your computer:</label>', $output );
+		$this->assertContains( 'This JSON file should come from the export link or bulk action in the', $output );
 	}
 
 	/**


### PR DESCRIPTION
This adds some more explanation to the Block Lab importer:

>This JSON file should come from the export link or bulk action in the Content Blocks screen, not from the main Export tool.



<img width="927" alt="this-is-added" src="https://user-images.githubusercontent.com/4063887/69755037-f37c7d80-111c-11ea-88c4-9f270fab5cb3.png">

This clarifies that it's not possible to export the blocks from here:

<img width="587" alt="import-from-here" src="https://user-images.githubusercontent.com/4063887/69755098-19a21d80-111d-11ea-8492-cc35109526e8.png">

...and then import them using this:

<img width="968" alt="sing-impor" src="https://user-images.githubusercontent.com/4063887/69755195-4f470680-111d-11ea-836f-22618ec9d6c0.png">


Maybe this isn't the best wording, feel free to suggest something else.