### PR TITLE
Set the posts_per_page to 100

### DIFF
--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -554,7 +554,7 @@ class Loader extends Component_Abstract {
 			[
 				'post_type'      => block_lab()->get_post_type_slug(),
 				'post_status'    => 'publish',
-				'posts_per_page' => - 1,
+				'posts_per_page' => 100,
 			]
 		);
 

--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -554,7 +554,7 @@ class Loader extends Component_Abstract {
 			[
 				'post_type'      => block_lab()->get_post_type_slug(),
 				'post_status'    => 'publish',
-				'posts_per_page' => 100,
+				'posts_per_page' => 100, // This has to have a limit for this plugin to be scalable.
 			]
 		);
 


### PR DESCRIPTION
This should help the case that Block Lab performs well, and is scalable (#485).

The `-1` value probably wouldn't get past a VIP review. 

Ideally, people creating more than 100 blocks in the 'Edit Block' UI would use the PHP API.