### PR TITLE
Version bump 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog #
 
+### 1.5.2 – 2019-12-02 ###
+
+Some small tweaks to the Block Importer and onboarding dialogs.
+
+* New: Selective import now allows you to choose which of the blocks contained in your export file you'd like to import
+* Fix: Onboarding notices are fixed so that they show in the right places, and at the right times
+
 ### 1.5.1 – 2019-11-11 ###
 
 This is a bugfix release, focused mostly on compatibility with WordPress 5.3.

--- a/block-lab.php
+++ b/block-lab.php
@@ -9,7 +9,7 @@
  * Plugin Name: Block Lab
  * Plugin URI: https://getblocklab.com
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.5.1
+ * Version: 1.5.2
  * Author: Block Lab
  * Author URI: https://getblocklab.com
  * License: GPL2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "block-lab",
   "title": "Block Lab",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "homepage": "https://getblocklab.com",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Some small tweaks to the Block Importer and onboarding dialogs.

* New: Selective import now allows you to choose which of the blocks contained in your export file you'd like to import
* Fix: Onboarding notices are fixed so that they show in the right places, and at the right times