### PR TITLE
Add GitHub templates, update CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report a problem
+
+---
+
+## Bug summary
+
+<!-- In 1-2 sentences, what is the bug? -->
+
+## Steps to reproduce
+
+<!-- Exactly how to reproduce it -->
+1. Navigate to...
+2. Click...
+3. Etc...
+
+## Expected behavior
+
+## Actual behaviour
+<!-- Please include screenshots of the behavior and the JS console, if there was an error or warning there --> 
+
+## Additional information
+
+## Suspected cause (optional)
+<!-- If you think you know what caused this bug --> 
+
+## Versions
+
+ - WordPress version:
+ - Block Lab version:
+<!-- Please ensure the latest version of Block Lab is running: https://github.com/getblocklab/block-lab/releases -->
+ - Gutenberg plugin version (if active):
+ - OS:
+ - Browser:
+ - Device: <!-- like MacBook -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ about: Report a problem
 
 ## Expected behavior
 
-## Actual behaviour
+## Actual behavior
 <!-- Please include screenshots of the behavior and the JS console, if there was an error or warning there --> 
 
 ## Additional information

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,8 +28,7 @@ about: Report a problem
 ## Versions
 
  - WordPress version:
- - Block Lab version:
-<!-- Please ensure the latest version of Block Lab is running: https://github.com/getblocklab/block-lab/releases -->
+ - Block Lab version: <!-- Please ensure the latest version of Block Lab is running: https://github.com/getblocklab/block-lab/releases -->
  - Gutenberg plugin version (if active):
  - OS:
  - Browser:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Request an enhancement, not a bug fix
+
+---
+
+## Feature description
+<!-- In as much detail as possible -->
+
+## Screenshot (optional)
+<!-- Even a simple mock-up of the feature would help -->
+
+## Use case
+<!-- What's your use case for this feature? This can help if we can't implement it exactly, as we might still be able to address your case. -->
+
+## Additional information

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -1,0 +1,11 @@
+---
+name: Support Request
+about: Please direct support requests to the support forum
+
+---
+
+For questions about how to use a feature, or whether a feature exists, please go to the [WordPress.org support forum](https://wordpress.org/support/plugin/block-lab/).
+
+Here's the plugin's [documentation](https://getblocklab.com/docs/).
+
+Thanks!

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -1,5 +1,5 @@
 ---
-name: Support Request
+name: Support request
 about: Please direct support requests to the support forum
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+<!--- Please summarize this PR in the title above -->
+
+#### Changes
+<!--- What does this PR change? -->
+*
+
+Fixes #
+<!-- If there is no issue for this PR, please add testing instructions as applicable -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,75 +29,17 @@ This project and everyone participating in it is governed by the [Block Lab Code
 
 ### Reporting Bugs
 
-This section guides you through submitting a bug report for Block Lab.  Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/).
 
-Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one.  When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report).
-
-> **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
-
-#### Before Submitting A Bug Report
-
-* You might be able to find the cause of the problem and fix things yourself.  Most importantly, check if you can reproduce the problem [in the latest version of Block Lab](https://github.com/getblocklab/block-lab/releases).
-* **Check the [FAQs](https://getblocklab.com/docs/faqs/)** for a list of common questions and problems.
-* While entering the title of your new issue, GitHub might show related issues below. If a related issue describes your problem and it's still open, add a comment to the existing issue instead of opening a new one.
-
-#### How Do I Submit A (Good) Bug Report?
-
-Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/) and ideally includes the following information by filling in [the template](ISSUE_TEMPLATE.md).
-
-Explain the problem and include additional details to help maintainers reproduce the problem:
-
-* **Use a clear and descriptive title** for the issue to identify the problem.
-* **Describe the exact steps which reproduce the problem** in as many details as possible.  When listing steps, **don't just say what you did, but explain how you did it**.  For example, if you moved the cursor to the end of a line, explain if you used the mouse or the keyboard.
-* **Provide specific examples to demonstrate the steps**.  Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples.  If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
-* **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
-* **Explain which behavior you expected to see instead and why.**
-* **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem.  You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
-* **If the problem wasn't triggered by a specific action**, describe what you were doing before the problem happened and share more information using the guidelines below.
-
-Provide more context by answering these questions:
-
-* **Did the problem start happening recently** (e.g. after updating to a new version of Block Lab) or was this always a problem?
-* If the problem started happening recently, **can you reproduce the problem in an older version of Block Lab?**  What's the most recent version in which the problem doesn't happen?  You can download older versions of Block Lab from [the releases page](https://github.com/getblocklab/block-lab/releases).
-* **Can you reliably reproduce the issue?**  If not, provide details about how often the problem happens and under which conditions it normally happens.
-
-Include details about your configuration and environment:
-
-* **Which version of Block Lab are you using?**
-* **What version of WordPress are you using**?  What other software versions are in use?
-* **Which themes and other plugins do you have installed?**
+Explain the problem and include additional details to help maintainers reproduce the problem.
 
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for Block Lab, including completely new features and minor improvements to existing functionality.  Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+Enhancement suggestions are also tracked as [GitHub issues](https://guides.github.com/features/issues/).
 
-Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion) as you might find out that you don't need to create one.  When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion).  Fill in [the template](ISSUE_TEMPLATE.md), including the steps that you imagine you would take if the feature you're requesting existed.
-
-#### Before Submitting An Enhancement Suggestion
-
-While entering the title of your new issue, GitHub may show related issues. If a related issue captures your idea, add a comment to the existing issue instead of opening a new one.
-
-#### How Do I Submit A (Good) Enhancement Suggestion?
-
-Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/) and ideally provides the following information:
-
-* **Use a clear and descriptive title** for the issue to identify the suggestion.
-* **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
-* **Provide specific examples to demonstrate the steps**.  Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
-* **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
-* **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of Block Lab which the suggestion is related to.  You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
-* **Explain why this enhancement would be useful** to most Block Lab users.
-* **Specify which version of Block Lab you're using.**
-* **Specify the WordPress version you're using.**
+Please describe in detail the enhancement and your use case for it.
 
 ### Your First Code Contribution
-
-Unsure where to begin contributing to Block Lab?  You can start by looking through these `good-first-issue` and `help-wanted` issues:
-
-* [New contributor issues][good-first-issue] - issues which should only require a few lines of code, and a test or two.
-* [Help wanted issues][help-wanted] - issues which should be a bit more involved than `good-first-issue` issues.
-
-Both issue lists are sorted by total number of comments.  While not perfect, number of comments is a reasonable proxy for impact a given change will have.
 
 ### Pull Requests
 
@@ -110,7 +52,7 @@ The process described here has several goals:
 
 Please follow these steps to have your contribution considered by the maintainers:
 
-1. Follow all instructions in [the template](PULL_REQUEST_TEMPLATE.md)
+1. Follow all instructions in [the template](.github/PULL_REQUEST_TEMPLATE.md)
 2. Follow the [styleguides](#styleguides)
 3. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing <details><summary>What if the status checks are failing?</summary>If a status check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated.  A maintainer will re-run the status check for you.  If we conclude that the failure was a false positive, then we will open an issue to track that problem with our status check suite.</details>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,13 +43,6 @@ Please describe in detail the enhancement and your use case for it.
 
 ### Pull Requests
 
-The process described here has several goals:
-
-- Maintain Block Lab's quality
-- Fix problems that are important to users
-- Engage the community in working toward the best possible Block Lab
-- Enable a sustainable system for Block Lab's maintainers to review contributions
-
 Please follow these steps to have your contribution considered by the maintainers:
 
 1. Follow all instructions in [the template](.github/PULL_REQUEST_TEMPLATE.md)
@@ -81,7 +74,7 @@ While the prerequisites above must be satisfied prior to having your pull reques
 
 ### Local Setup
 
-Block Lab development requires Node.js and follows the WordPress coding standards for PHP and JavaScript. In order to get your development enviorment setup quickly, simply run the following commands after cloning the plugin from Github:
+Block Lab development requires Node.js and follows the WordPress coding standards for PHP and JavaScript. In order to get your development environment setup quickly, simply run the following commands after cloning the plugin from Github:
 
 #### Node
 
@@ -106,8 +99,6 @@ While developing, it is a best practice to watch for changes. This command will 
 ```
 composer install
 ```
-
-Also while developing, it is advantageous to install the Composer dependencies to ensure adherence to PHP WordPress coding standards.
 
 ## Additional Notes
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,6 +89,7 @@ gulp.task( 'clean:bundle', function () {
 		'package/trunk/README.md',
 		'package/trunk/CHANGELOG.md',
 		'package/trunk/webpack.config.js',
+		'package/trunk/.github',
 		'package/prepare',
 	] );
 } );


### PR DESCRIPTION
`CONTRIBUTING.md` has a lot of good instructions, but since it was written, it's become much more common to have issue and PR templates.

This should make it easier for us when we get bug reports, as the template has a 'Steps to reproduce' section.

Inspired by the templates in the [AMP plugin](https://github.com/ampproject/amp-wp/blob/0c7ba2b46390420ca0c6dee069d0ae5322b3084f/.github/ISSUE_TEMPLATE/bug_report.md) and [Jetpack](https://github.com/Automattic/jetpack/blob/8537cdd3fce9e3c3d0ff9847563d0ce2ea5ea8cf/.github/ISSUE_TEMPLATE/bug_report.md).

Now, when people open a bug report, it'll look something like:

<img width="832" alt="new-br" src="https://user-images.githubusercontent.com/4063887/71215586-c6377100-227d-11ea-94b4-cddd24e31f1c.png">

