### PR TITLE
Use get_post() instead of the_post() as an argument

### DIFF
--- a/php/admin/class-onboarding.php
+++ b/php/admin/class-onboarding.php
@@ -312,7 +312,7 @@ class Onboarding extends Component_Abstract {
 			return;
 		}
 
-		$categories = get_block_categories( the_post() );
+		$categories = get_block_categories( get_post() );
 
 		$example_post_id = wp_insert_post(
 			[

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -1040,7 +1040,7 @@ class Block_Post extends Component_Abstract {
 		// Block category.
 		if ( isset( $_POST['block-properties-category'] ) ) {
 			$category_slug = sanitize_key( $_POST['block-properties-category'] );
-			$categories    = get_block_categories( the_post() );
+			$categories    = get_block_categories( get_post() );
 
 			if ( '__custom' === $category_slug && isset( $_POST['block-properties-category-name'] ) ) {
 				$category = [


### PR DESCRIPTION
Sometimes, there is a fatal error on saving a Block Lab post. But I couldn't reproduce this on a machine with PHP 7.2.

## Steps to reproduce
1. Create a new Block Lab block
2. Name the block
3. Add a field and give it any name
4. Save the block
<img width="1340" alt="setup-error-here" src="https://user-images.githubusercontent.com/4063887/71636142-ebb76980-2bf1-11ea-94ba-b6a1b97ee8b6.png">

5. Expected: the block should save
6. Actual: there's a PHP error:
>( ! ) Notice: Trying to access array offset on value of type null in bl/wp-includes/class-wp-query.php on line 3252

<img width="1335" alt="error-here" src="https://user-images.githubusercontent.com/4063887/71636157-0093fd00-2bf2-11ea-837a-01028880e7ee.png">

Block Lab branch: `develop`
WP Core: 5.3, 5.3.1, 5.3.2 (haven't tested others)
PHP version: 7.4.1 (didn't occur on another machine with 7.2.25)