### PR TITLE
Update copyright from 2019 to 2020

### DIFF
--- a/block-lab.php
+++ b/block-lab.php
@@ -3,7 +3,7 @@
  * Block Lab
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  *
  * Plugin Name: Block Lab

--- a/js/admin.block-post.js
+++ b/js/admin.block-post.js
@@ -2,7 +2,7 @@
  * Used for editing Blocks.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/admin/class-admin.php
+++ b/php/admin/class-admin.php
@@ -3,7 +3,7 @@
  * WP Admin resources.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license   http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/admin/class-import.php
+++ b/php/admin/class-import.php
@@ -3,7 +3,7 @@
  * Block Lab Importer.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license   http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/admin/class-license.php
+++ b/php/admin/class-license.php
@@ -3,7 +3,7 @@
  * Enable and validate Pro version licensing.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license   http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/admin/class-settings.php
+++ b/php/admin/class-settings.php
@@ -3,7 +3,7 @@
  * Block Lab Settings.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license   http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/admin/class-upgrade.php
+++ b/php/admin/class-upgrade.php
@@ -3,7 +3,7 @@
  * Block Lab Upgrade Page.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license   http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/autoloader.php
+++ b/php/autoloader.php
@@ -3,7 +3,7 @@
  * Plugin Autoloader
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/class-block.php
+++ b/php/blocks/class-block.php
@@ -3,7 +3,7 @@
  * Block.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/class-field.php
+++ b/php/blocks/class-field.php
@@ -3,7 +3,7 @@
  * Block Field.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/class-loop.php
+++ b/php/blocks/class-loop.php
@@ -3,7 +3,7 @@
  * Repeater row looping.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-checkbox.php
+++ b/php/blocks/controls/class-checkbox.php
@@ -3,7 +3,7 @@
  * Radio control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-classic-text.php
+++ b/php/blocks/controls/class-classic-text.php
@@ -3,7 +3,7 @@
  * Classic Text control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-color.php
+++ b/php/blocks/controls/class-color.php
@@ -3,7 +3,7 @@
  * Color control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-control-abstract.php
+++ b/php/blocks/controls/class-control-abstract.php
@@ -3,7 +3,7 @@
  * Control abstract.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-control-setting.php
+++ b/php/blocks/controls/class-control-setting.php
@@ -3,7 +3,7 @@
  * Control_Setting.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-email.php
+++ b/php/blocks/controls/class-email.php
@@ -3,7 +3,7 @@
  * Email control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-image.php
+++ b/php/blocks/controls/class-image.php
@@ -3,7 +3,7 @@
  * Image control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-multiselect.php
+++ b/php/blocks/controls/class-multiselect.php
@@ -3,7 +3,7 @@
  * Select control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-number.php
+++ b/php/blocks/controls/class-number.php
@@ -3,7 +3,7 @@
  * Number control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-post.php
+++ b/php/blocks/controls/class-post.php
@@ -3,7 +3,7 @@
  * Post control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-radio.php
+++ b/php/blocks/controls/class-radio.php
@@ -3,7 +3,7 @@
  * Radio control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-range.php
+++ b/php/blocks/controls/class-range.php
@@ -3,7 +3,7 @@
  * Range control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-repeater.php
+++ b/php/blocks/controls/class-repeater.php
@@ -3,7 +3,7 @@
  * Repeater control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-rich-text.php
+++ b/php/blocks/controls/class-rich-text.php
@@ -3,7 +3,7 @@
  * Rich Text control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-select.php
+++ b/php/blocks/controls/class-select.php
@@ -3,7 +3,7 @@
  * Select control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-taxonomy.php
+++ b/php/blocks/controls/class-taxonomy.php
@@ -3,7 +3,7 @@
  * Taxonomy control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-text.php
+++ b/php/blocks/controls/class-text.php
@@ -3,7 +3,7 @@
  * Text control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-textarea.php
+++ b/php/blocks/controls/class-textarea.php
@@ -3,7 +3,7 @@
  * Textarea control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-toggle.php
+++ b/php/blocks/controls/class-toggle.php
@@ -3,7 +3,7 @@
  * Toggle control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-url.php
+++ b/php/blocks/controls/class-url.php
@@ -3,7 +3,7 @@
  * Url control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/blocks/controls/class-user.php
+++ b/php/blocks/controls/class-user.php
@@ -3,7 +3,7 @@
  * User control.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/class-component-abstract.php
+++ b/php/class-component-abstract.php
@@ -3,7 +3,7 @@
  * Component abstract.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/class-component-interface.php
+++ b/php/class-component-interface.php
@@ -3,7 +3,7 @@
  * Component interface.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/class-plugin-abstract.php
+++ b/php/class-plugin-abstract.php
@@ -3,7 +3,7 @@
  * Plugin abstract.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/class-plugin-interface.php
+++ b/php/class-plugin-interface.php
@@ -3,7 +3,7 @@
  * Plugin interface.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -3,7 +3,7 @@
  * Primary plugin file.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license   http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -3,7 +3,7 @@
  * Helper functions.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/post-types/class-block-post.php
+++ b/php/post-types/class-block-post.php
@@ -3,7 +3,7 @@
  * Block Post Type.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/views/license.php
+++ b/php/views/license.php
@@ -3,7 +3,7 @@
  * Block Lab settings form for the License tab.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license   http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 

--- a/php/views/upgrade.php
+++ b/php/views/upgrade.php
@@ -3,7 +3,7 @@
  * Block Lab Pro upgrade page.
  *
  * @package   Block_Lab
- * @copyright Copyright(c) 2019, Block Lab
+ * @copyright Copyright(c) 2020, Block Lab
  * @license   http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
  */
 


### PR DESCRIPTION
Like we did last year, this updates the `@copyright` tags.