### PR TITLE
Add a pre-commit hook that only lints staged JS and PHP files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ node_modules
 # Composer
 composer.lock
 vendor
+cghooks.lock
 
 # Tests
 tests/data/

--- a/bin/pre-commit.sh
+++ b/bin/pre-commit.sh
@@ -1,0 +1,17 @@
+# Lint staged PHP files
+php_files=$( git diff --diff-filter=d --staged --name-only | grep -E '/*\.php$' )
+if [ ! -z "$php_files" ]; then
+    npm run lint:php $php_files
+    if [ $? != 0 ]; then
+        exit 1
+    fi
+fi
+
+# Lint staged JS files
+js_files=$( git diff --diff-filter=d --staged --name-only | grep -E '^js\/\S*\.js$' )
+if [ ! -z "$js_files" ]; then
+    npm run lint:js:files $js_files
+    if [ $? != 0 ]; then
+        exit 1
+    fi
+fi

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,20 @@
     },
     "require-dev": {
         "brain/monkey": "^2",
+        "brainmaestro/composer-git-hooks": "^2.8",
         "dealerdirect/phpcodesniffer-composer-installer": "0.5.0",
         "mockery/mockery": "^1.2.4",
         "phpcompatibility/phpcompatibility-wp": "2.1.0",
         "squizlabs/php_codesniffer": "^3.4",
         "wp-coding-standards/wpcs": "2.2.0"
+    },
+    "extra": {
+        "hooks": {
+            "pre-commit": "bash bin/pre-commit.sh"
+        }
+    },
+    "scripts": {
+        "post-install-cmd": "cghooks add --ignore-lock",
+        "post-update-cmd": "cghooks update"
     }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -92,6 +92,7 @@ gulp.task( 'clean:bundle', function () {
 		'package/trunk/CHANGELOG.md',
 		'package/trunk/webpack.config.js',
 		'package/trunk/.github',
+		'package/trunk/cghooks.lock',
 		'package/prepare',
 	] );
 } );

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "build": "wp-scripts build",
     "lint": "npm-run-all --parallel lint:*",
     "lint:js": "wp-scripts lint-js js",
+    "lint:js:files": "wp-scripts lint-js",
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:pkg-json": "wp-scripts lint-pkg-json",
     "lint:php": "vendor/bin/phpcs",


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes

* Inspired by Weston Ruter's example pre-commit hook
* Uses composer-git-hooks to run this
* So on running composer install, this hook will be installed
* This only lints staged JS and PHP files, so it can run quickly

#### Testing Instructions
1. do `composer install`
2. Create an intentional `phpcs` error in any PHP file, like adding an extra space inside parentheses
3. Stage the change
4. Attempt to commit it
5. The pre-commit hook should prevent committing it
6. Repeat steps 2-5, but for a file in `js/`

