### PR TITLE
Add Jest unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
       env: WP_VERSION=trunk
     - php: 5.6
       env: WP_TRAVISCI=lint
+    - php: 7.3
+      env: WP_TRAVISCI=test-js
 
 install:
   - composer install

--- a/js/blocks/components/block-lab-inspector.js
+++ b/js/blocks/components/block-lab-inspector.js
@@ -8,7 +8,7 @@ import { applyFilters } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import simplifiedFields from '../loader/fields';
+import { getSimplifiedFields } from '../helpers';
 import controls from '../controls';
 
 /**
@@ -20,7 +20,7 @@ import controls from '../controls';
  * @return {Function|null} The inspector controls.
  */
 const BlockLabInspector = ( { blockProps, block } ) => {
-	const fields = simplifiedFields( block.fields ).map( ( field ) => {
+	const fields = getSimplifiedFields( block.fields ).map( ( field ) => {
 		// If it's not meant for the inspector, continue (return null).
 		if ( ! field.location || ! field.location.includes( 'inspector' ) ) {
 			return null;

--- a/js/blocks/components/fields.js
+++ b/js/blocks/components/fields.js
@@ -7,7 +7,7 @@ import { select } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import simplifiedFields from '../loader/fields';
+import { getSimplifiedFields } from '../helpers';
 import controls from '../controls';
 
 /**
@@ -48,7 +48,7 @@ const getClassName = ( field ) => {
  * @return {Function} fields The rendered fields.
  */
 const Fields = ( { fields, parentBlockProps, parentBlock, rowIndex } ) => {
-	return simplifiedFields( fields ).map( ( field ) => {
+	return getSimplifiedFields( fields ).map( ( field ) => {
 		if ( field.location && ! field.location.includes( 'editor' ) ) {
 			return null; // This is not meant for the editor.
 		}

--- a/js/blocks/helpers/getBlockLabAttributes.js
+++ b/js/blocks/helpers/getBlockLabAttributes.js
@@ -4,7 +4,7 @@
  * @param {Object} fields The fields to get the attributes from.
  * @return {Object} attributes The attributes for the fields.
  */
-const getBlockAttributes = ( fields ) => {
+const getBlockLabAttributes = ( fields ) => {
 	const attributes = {};
 
 	for ( const fieldName in fields ) {
@@ -13,14 +13,13 @@ const getBlockAttributes = ( fields ) => {
 		}
 
 		const field = fields[ fieldName ];
-
 		attributes[ fieldName ] = {};
 
-		if ( field.type ) {
+		if ( field.hasOwnProperty( 'type' ) ) {
 			attributes[ fieldName ].type = field.type;
 		}
 
-		if ( field.default ) {
+		if ( field.hasOwnProperty( 'default' ) ) {
 			attributes[ fieldName ].default = field.default;
 		}
 	}
@@ -28,4 +27,4 @@ const getBlockAttributes = ( fields ) => {
 	return attributes;
 };
 
-export default getBlockAttributes;
+export default getBlockLabAttributes;

--- a/js/blocks/helpers/getBlockLabAttributes.js
+++ b/js/blocks/helpers/getBlockLabAttributes.js
@@ -15,11 +15,11 @@ const getBlockLabAttributes = ( fields ) => {
 		const field = fields[ fieldName ];
 		attributes[ fieldName ] = {};
 
-		if ( field.hasOwnProperty( 'type' ) ) {
+		if ( field.type ) {
 			attributes[ fieldName ].type = field.type;
 		}
 
-		if ( field.hasOwnProperty( 'default' ) ) {
+		if ( field.default ) {
 			attributes[ fieldName ].default = field.default;
 		}
 	}

--- a/js/blocks/helpers/getSimplifiedFields.js
+++ b/js/blocks/helpers/getSimplifiedFields.js
@@ -21,7 +21,7 @@ const compare = ( a, b ) => {
  * @param {Array} fields The fields to simplify.
  * @return {Array} The simplified fields.
  */
-const simplifiedFields = ( fields ) => {
+const getSimplifiedFields = ( fields ) => {
 	const fieldList = [];
 
 	for ( const fieldName in fields ) {
@@ -42,9 +42,9 @@ const simplifiedFields = ( fields ) => {
 		);
 	}
 
-	fieldList.sort( compare );
+	fieldList.sort( compare ); // @todo: is this needed? Even then, it should only affect the Block Lab editor UI.
 
 	return fieldList;
 };
 
-export default simplifiedFields;
+export default getSimplifiedFields;

--- a/js/blocks/helpers/index.js
+++ b/js/blocks/helpers/index.js
@@ -1,0 +1,3 @@
+export { default as getBlockLabAttributes } from './getBlockLabAttributes';
+export { default as getSimplifiedFields } from './getSimplifiedFields';
+export { default as registerBlocks } from './registerBlocks';

--- a/js/blocks/helpers/registerBlocks.js
+++ b/js/blocks/helpers/registerBlocks.js
@@ -1,4 +1,3 @@
-
 /**
  * WordPress dependencies
  */

--- a/js/blocks/helpers/registerBlocks.js
+++ b/js/blocks/helpers/registerBlocks.js
@@ -1,4 +1,3 @@
-/* global blockLab, blockLabBlocks */
 
 /**
  * WordPress dependencies
@@ -9,13 +8,16 @@ import { registerBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import icons from '../../../assets/icons.json';
-import getBlockAttributes from './attributes';
-import { Edit } from '../components';
-import '../../../css/src/editor.scss';
+import { getBlockLabAttributes } from './';
 
-const registerBlocks = () => {
-	// Loop through all the blocks.
-	// Note: This is not guaranteed to be sequential.
+/**
+ * Loops through all of the blocks, but not guaranteed to be sequential.
+ *
+ * @param {Object} blockLab Block Lab properties, available via wp_localize_script().
+ * @param {Object} blockLabBlocks The registered Block Lab blocks, available via wp_add_inline_script().
+ * @param {Function} EditComponent The edit component to render the blocks.
+ */
+const registerBlocks = ( blockLab, blockLabBlocks, EditComponent ) => {
 	for ( const blockName in blockLabBlocks ) {
 		// Avoid weird inheritance issues. Which should not happen because the backend is safe.
 		if ( ! blockLabBlocks.hasOwnProperty( blockName ) ) {
@@ -46,9 +48,9 @@ const registerBlocks = () => {
 			category: 'object' === typeof block.category ? block.category.slug : block.category,
 			icon,
 			keywords: block.keywords,
-			attributes: getBlockAttributes( block.fields ),
-			edit: ( props ) => {
-				return <Edit blockProps={ props } block={ block } />;
+			attributes: getBlockLabAttributes( block.fields ),
+			edit( props ) {
+				return <EditComponent blockProps={ props } block={ block } />;
 			},
 			save() {
 				return null;
@@ -57,4 +59,4 @@ const registerBlocks = () => {
 	}
 };
 
-export default registerBlocks();
+export default registerBlocks;

--- a/js/blocks/helpers/test/getBlockLabAttributes.js
+++ b/js/blocks/helpers/test/getBlockLabAttributes.js
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import { getBlockLabAttributes } from '../';
+
+describe( 'getBlockFromContent', () => {
+	const fieldsWithOnlyType = {
+		example_email: {
+			type: 'email',
+		},
+		example_post: {
+			type: 'post',
+		},
+	};
+
+	it( 'should return an empty object if passed an empty object', () => {
+		expect( getBlockLabAttributes( {} ) ).toStrictEqual( {} );
+	} );
+
+	it( 'should not throw an error if certain attributes are not present', () => {
+		expect( getBlockLabAttributes( fieldsWithOnlyType ) ).toStrictEqual( fieldsWithOnlyType );
+	} );
+
+	it( 'should return only the attributes of the fields', () => {
+		expect( getBlockLabAttributes( {
+			example_text: {
+				type: 'text',
+				default: 'Here is some text',
+				help: 'This is the help text',
+				location: 'editor',
+			},
+			example_url: {
+				type: 'url',
+				default: 'https://example.com/go-here',
+				help: 'Here is the help text',
+				location: 'inspector',
+			},
+		} ) ).toStrictEqual( {
+			example_text: {
+				type: 'text',
+				default: 'Here is some text',
+			},
+			example_url: {
+				type: 'url',
+				default: 'https://example.com/go-here',
+			},
+		} );
+	} );
+} );

--- a/js/blocks/helpers/test/getSimplifiedFields.js
+++ b/js/blocks/helpers/test/getSimplifiedFields.js
@@ -1,0 +1,70 @@
+/**
+ * Internal dependencies
+ */
+import { getSimplifiedFields } from '../';
+
+describe( 'getBlockFromContent', () => {
+	it( 'should return an empty array if passed an empty object', () => {
+		expect( getSimplifiedFields( {} ) ).toStrictEqual( [] );
+	} );
+
+	it( 'should return simplified fields for an object of 3 fields', () => {
+		expect( getSimplifiedFields( {
+			example_post: {
+				type: 'post',
+				help: 'This is some example help text',
+				location: 'editor',
+				post_type: 'posts',
+				width: '100',
+			},
+			example_classic_text: {
+				type: 'classic_text',
+				default: 'https://example.com/go-here',
+				help: 'Here is the help text',
+				location: 'editor',
+			},
+			example_user: {
+				type: 'user',
+				default: 'https://example.com/go-here',
+				help: 'Here is the help text',
+				location: 'inspector',
+			},
+		} ) ).toStrictEqual( [
+			{
+				name: 'example_post',
+				type: 'post',
+				help: 'This is some example help text',
+				location: 'editor',
+				post_type: 'posts',
+				width: '100',
+			},
+			{
+				name: 'example_classic_text',
+				type: 'classic_text',
+				default: 'https://example.com/go-here',
+				help: 'Here is the help text',
+				location: 'editor',
+			},
+			{
+				name: 'example_user',
+				type: 'user',
+				default: 'https://example.com/go-here',
+				help: 'Here is the help text',
+				location: 'inspector',
+			},
+		] );
+	} );
+
+	it( 'should still include falsy values in the simplified fields', () => {
+		expect( getSimplifiedFields( {
+			test_taxonomy: {
+				default: '',
+			},
+		} ) ).toStrictEqual( [
+			{
+				name: 'test_taxonomy',
+				default: '',
+			},
+		] );
+	} );
+} );

--- a/js/blocks/helpers/test/registerBlocks.js
+++ b/js/blocks/helpers/test/registerBlocks.js
@@ -11,6 +11,15 @@ jest.mock( '@wordpress/blocks', () => {
 	};
 } );
 const Edit = () => {};
+const expectedArgs = {
+	title: expect.any( String ),
+	category: expect.any( String ),
+	icon: expect.any( String ),
+	keywords: expect.any( Array ),
+	attributes: expect.any( Object ),
+	edit: expect.any( Function ),
+	save: expect.any( Function ),
+};
 
 describe( 'registerBlocks', () => {
 	it( 'should not register any block if there is no Block Lab block passed', () => {
@@ -30,15 +39,7 @@ describe( 'registerBlocks', () => {
 		registerBlocks( {}, blockLabBlocks, Edit );
 		expect( mockRegisterBlockType ).toHaveBeenCalledWith(
 			blockName,
-			expect.objectContaining( {
-				title: expect.any( String ),
-				category: expect.any( String ),
-				icon: expect.any( String ),
-				keywords: expect.any( Array ),
-				attributes: expect.any( Object ),
-				edit: expect.any( Function ),
-				save: expect.any( Function ),
-			} )
+			expect.objectContaining( expectedArgs )
 		);
 	} );
 
@@ -63,15 +64,7 @@ describe( 'registerBlocks', () => {
 		expect( mockRegisterBlockType ).toHaveBeenNthCalledWith(
 			2,
 			expect.any( String ),
-			expect.objectContaining( {
-				title: expect.any( String ),
-				category: expect.any( String ),
-				icon: expect.any( String ),
-				keywords: expect.any( Array ),
-				attributes: expect.any( Object ),
-				edit: expect.any( Function ),
-				save: expect.any( Function ),
-			} )
+			expect.objectContaining( expectedArgs )
 		);
 	} );
 } );

--- a/js/blocks/helpers/test/registerBlocks.js
+++ b/js/blocks/helpers/test/registerBlocks.js
@@ -1,0 +1,77 @@
+
+/**
+ * Internal dependencies
+ */
+import { registerBlocks } from '../';
+
+const mockRegisterBlockType = jest.fn();
+jest.mock( '@wordpress/blocks', () => {
+	return {
+		registerBlockType: ( ...args ) => mockRegisterBlockType( ...args ),
+	};
+} );
+const Edit = () => {};
+
+describe( 'registerBlocks', () => {
+	it( 'should not register any block if there is no Block Lab block passed', () => {
+		registerBlocks( {}, {}, Edit );
+		expect( mockRegisterBlockType ).toHaveBeenCalledTimes( 0 );
+	} );
+
+	it( 'should register a single block', () => {
+		const blockName = 'block-lab/test-post';
+		const blockLabBlocks = {};
+		blockLabBlocks[ blockName ] = {
+			title: 'Test Post',
+			category: 'widget',
+			keywords: [ 'foobaz', 'example' ],
+		};
+
+		registerBlocks( {}, blockLabBlocks, Edit );
+		expect( mockRegisterBlockType ).toHaveBeenCalledWith(
+			blockName,
+			expect.objectContaining( {
+				title: expect.any( String ),
+				category: expect.any( String ),
+				icon: expect.any( String ),
+				keywords: expect.any( Array ),
+				attributes: expect.any( Object ),
+				edit: expect.any( Function ),
+				save: expect.any( Function ),
+			} )
+		);
+	} );
+
+	it( 'should register two blocks', () => {
+		registerBlocks(
+			{},
+			{
+				'block-lab/example-post': {
+					title: 'An Example Post',
+					category: 'widget',
+					keywords: [ 'foobaz', 'example' ],
+				},
+				'block-lab/example-email': {
+					title: 'Example Email',
+					category: 'widget',
+					keywords: [ 'example-keyword', 'another' ],
+				},
+			},
+			Edit
+		);
+
+		expect( mockRegisterBlockType ).toHaveBeenNthCalledWith(
+			2,
+			expect.any( String ),
+			expect.objectContaining( {
+				title: expect.any( String ),
+				category: expect.any( String ),
+				icon: expect.any( String ),
+				keywords: expect.any( Array ),
+				attributes: expect.any( Object ),
+				edit: expect.any( Function ),
+				save: expect.any( Function ),
+			} )
+		);
+	} );
+} );

--- a/js/blocks/i18n.js
+++ b/js/blocks/i18n.js
@@ -1,1 +1,0 @@
-wp.i18n.setLocaleData( { '': {} }, 'block-lab' );

--- a/js/blocks/index.js
+++ b/js/blocks/index.js
@@ -3,7 +3,7 @@
 /**
  * WordPress dependencies
  */
-const { i18n } = wp;
+import { setLocaleData } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -11,5 +11,5 @@ const { i18n } = wp;
 import { registerBlocks } from './helpers';
 import { Edit } from './components';
 
-i18n.setLocaleData( { '': {} }, 'block-lab' );
+setLocaleData( { '': {} }, 'block-lab' );
 registerBlocks( blockLab, blockLabBlocks, Edit );

--- a/js/blocks/index.js
+++ b/js/blocks/index.js
@@ -1,8 +1,15 @@
-// Import localization. Need to import for global context.
+/* global blockLab, blockLabBlocks */
+
+/**
+ * WordPress dependencies
+ */
+const { i18n } = wp;
+
 /**
  * Internal dependencies
  */
-import './i18n';
+import { registerBlocks } from './helpers';
+import { Edit } from './components';
 
-// Import Block Lab loader.
-import './loader';
+i18n.setLocaleData( { '': {} }, 'block-lab' );
+registerBlocks( blockLab, blockLabBlocks, Edit );

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1,1 +1,0 @@
-// Import components.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10060,6 +10060,16 @@
       "integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==",
       "dev": true
     },
+    "jest-silent-reporter": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/jest-silent-reporter/-/jest-silent-reporter-0.1.2.tgz",
+      "integrity": "sha512-w/qc9NvWqdX0vZv6TUG4EE15d72+JxQJYh+3hqq8cTi3BnfBOtwNtL3T6TwkZSy/sfc3REW5niz0eSBPTIvWnA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.1",
+        "jest-util": "^24.0.0"
+      }
+    },
     "jest-snapshot": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
@@ -14418,16 +14428,16 @@
       }
     },
     "sass-loader": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.1.tgz",
-      "integrity": "sha512-ANR2JHuoxzCI+OPDA0hJBv1Y16A2021hucu0S3DOGgpukKzq9W+4vX9jhIqs4qibT5E7RIRsHMMrN0kdF5nUig==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
+      "integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
       "dev": true,
       "requires": {
         "clone-deep": "^4.0.1",
         "loader-utils": "^1.2.3",
         "neo-async": "^2.6.1",
         "schema-utils": "^2.6.1",
-        "semver": "^7.1.1"
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "clone-deep": {
@@ -14442,9 +14452,9 @@
           }
         },
         "schema-utils": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.1.tgz",
-          "integrity": "sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==",
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.2.tgz",
+          "integrity": "sha512-sazKNMBX/jwrXRkOI7N6dtiTVYqzSckzol8SGuHt0lE/v3xSW6cUkOqzu6Bq2tW+dlUzq3CWIqHU3ZKauliqdg==",
           "dev": true,
           "requires": {
             "ajv": "^6.10.2",
@@ -14452,9 +14462,9 @@
           }
         },
         "semver": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.1.tgz",
-          "integrity": "sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         },
         "shallow-clone": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "gulp": "^4.0.2",
     "gulp-run": "^1.7.1",
     "gulp-string-replace": "^1.1.2",
+    "jest-silent-reporter": "0.1.2",
     "merge-stream": "^2.0.0",
     "mini-css-extract-plugin": "0.8.2",
     "node-sass": "^4.13.0",
@@ -59,7 +60,7 @@
     "raw-loader": "^4.0.0",
     "re-resizable": "6.1.1",
     "react": "16.12.0",
-    "sass-loader": "^8.0.0",
+    "sass-loader": "^8.0.2",
     "style-loader": "^1.0.2",
     "uglifyjs-webpack-plugin": "^2.2.0",
     "webpack": "^4.41.3",
@@ -74,6 +75,7 @@
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:pkg-json": "wp-scripts lint-pkg-json",
     "lint:php": "vendor/bin/phpcs",
-    "lint:php:fix": "vendor/bin/phpcbf"
+    "lint:php:fix": "vendor/bin/phpcbf",
+    "test:js": "wp-scripts test-unit-js --config=tests/js/jest.config.js"
   }
 }

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+	rootDir: '../../',
+	...require( '@wordpress/scripts/config/jest-unit.config' ),
+	transform: {
+		'^.+\\.[jt]sx?$': '<rootDir>/node_modules/@wordpress/scripts/config/babel-transform',
+	},
+	testPathIgnorePatterns: [
+		'<rootDir>/.git',
+		'<rootDir>/node_modules',
+		'<rootDir>/js/build',
+	],
+	coveragePathIgnorePatterns: [
+		'<rootDir>/node_modules',
+		'<rootDir>/js/build',
+	],
+	coverageReporters: [ 'lcov' ],
+	coverageDirectory: '<rootDir>/coverage',
+	reporters: [ [ 'jest-silent-reporter', { useDots: true } ] ],
+};

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -7,11 +7,9 @@ module.exports = {
 	testPathIgnorePatterns: [
 		'<rootDir>/.git',
 		'<rootDir>/node_modules',
-		'<rootDir>/js/build',
 	],
 	coveragePathIgnorePatterns: [
 		'<rootDir>/node_modules',
-		'<rootDir>/js/build',
 	],
 	coverageReporters: [ 'lcov' ],
 	coverageDirectory: '<rootDir>/coverage',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,6 @@ module.exports = {
 	...defaultConfig,
 	entry: {
 		'./js/editor.blocks': './js/blocks/index.js',
-		'./js/scripts': './js/src/index.js',
 	},
 	output: {
 		path: path.resolve( __dirname ),


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Moves helper functions into `helpers/`, without changing them much
* Adds Jest tests for them

#### Testing
1. npm install
2. npm run test:js
3. Expected: only three dots display
4. npm run dev
5. Expected: the plugin's JS files still work, especially in the block editor

