### PR TITLE
Prevent an edge case notice, and a unit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ matrix:
 
 install:
   - composer install
+  - npm install
+  - npm run dev
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
@@ -57,7 +59,6 @@ before_script:
     if [[ "$WP_TRAVISCI" == "lint" ]] ; then
       composer global require wp-coding-standards/wpcs
       phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
-      npm install
       npm run lint:js
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ matrix:
 install:
   - composer install
   - npm install
-  - npm run build
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
@@ -63,6 +62,7 @@ before_script:
     fi
 
 script:
+  - npm run build
   - |
     if [[ ! -z "$WP_VERSION" ]] ; then
       phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
 install:
   - composer install
   - npm install
-  - npm run dev
+  - npm run build
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/tests/php/unit/blocks/test-class-loader.php
+++ b/tests/php/unit/blocks/test-class-loader.php
@@ -131,6 +131,31 @@ class Test_Loader extends Abstract_Template {
 	}
 
 	/**
+	 * Test editor_assets.
+	 *
+	 * @covers \Block_Lab\Blocks\Loader::editor_assets()
+	 */
+	public function test_editor_assets() {
+		$script_handle = 'block-lab-blocks';
+		$style_handle  = 'block-lab-editor-css';
+
+		$this->instance->init();
+		$this->invoke_protected_method( 'editor_assets' );
+
+		$this->assertTrue( wp_script_is( $script_handle ) );
+		$this->assertContains(
+			'var blockLab = {"authorBlocks"',
+			wp_scripts()->registered[ $script_handle ]->extra['data']
+		);
+		$this->assertContains(
+			'const blockLabBlocks =',
+			wp_scripts()->registered[ $script_handle ]->extra['before'][1]
+		);
+
+		$this->assertTrue( wp_style_is( $style_handle ) );
+	}
+
+	/**
 	 * Test render_block_template.
 	 *
 	 * @covers \Block_Lab\Blocks\Loader::render_block_template()


### PR DESCRIPTION
Once, I think when importing a block, this notice appeared:
>Notice: Trying to get property 'post_type' of non-object in /path/to/wp-content/plugins/block-lab/php/blocks/class-loader.php on line 183

This looks to be from `get_post()` returning something like `null`, and trying to access the `->post_type` property of that.

This is probably an edge case, I didn't see it before.

Sorry, I don't remember the steps to reproduce this.

#### Changes
* Handles a case of the global `$post` being `null`, or not having a `->post_type`
* Adds a basic test 
