### PR TITLE
Use a virtual filesystem in the PHPUnit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,20 +9,11 @@
     },
     "require-dev": {
         "brain/monkey": "^2",
-        "brainmaestro/composer-git-hooks": "^2.8",
         "dealerdirect/phpcodesniffer-composer-installer": "0.5.0",
+        "mikey179/vfsstream": "1.6.8",
         "mockery/mockery": "^1.2.4",
         "phpcompatibility/phpcompatibility-wp": "2.1.0",
         "squizlabs/php_codesniffer": "^3.4",
         "wp-coding-standards/wpcs": "2.2.0"
-    },
-    "extra": {
-        "hooks": {
-            "pre-commit": "bash bin/pre-commit.sh"
-        }
-    },
-    "scripts": {
-        "post-install-cmd": "cghooks add --ignore-lock",
-        "post-update-cmd": "cghooks update"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac9e7012000affee34fbf8397ddc63f2",
+    "content-hash": "b3f66d0d62bdb44a6cce1e5459e3dd0d",
     "packages": [],
     "packages-dev": [
         {
@@ -230,6 +230,52 @@
                 "test"
             ],
             "time": "2016-01-20T08:20:44+00:00"
+        },
+        {
+            "name": "mikey179/vfsstream",
+            "version": "v1.6.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bovigo/vfsStream.git",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "time": "2019-10-30T15:31:00+00:00"
         },
         {
             "name": "mockery/mockery",


### PR DESCRIPTION
* Some tests wrote to the actual filesystem, like in the `WP_TESTS_DIR` directory theme
* For example, the integration tests add template files to it in `example-theme/blocks/`
* This can create problems, when sometimes the cleanup doesn't work:
<img width="812" alt="links-here" src="https://user-images.githubusercontent.com/4063887/73234881-a84d0e00-4151-11ea-9afb-a6736bf5292d.png">


#### Changes

- [x] Use a virtual filesystem for the integration tests
- [ ] Use it for all other tests that write to the filesystem
