### PR TITLE
Move retrieval of blocks later to allow calling `get_terms()`

### DIFF
--- a/php/blocks/class-loader.php
+++ b/php/blocks/class-loader.php
@@ -72,9 +72,9 @@ class Loader extends Component_Abstract {
 		add_filter( 'block_categories', $this->get_callback( 'register_categories' ) );
 
 		/**
-		 * Block retrieval.
+		 * Block retrieval, must run before dynamic_block_loader().
 		 */
-		add_action( 'init', $this->get_callback( 'retrieve_blocks' ), 1 );
+		add_action( 'init', $this->get_callback( 'retrieve_blocks' ) );
 
 		/**
 		 * PHP block loading.

--- a/tests/php/unit/blocks/test-class-loader.php
+++ b/tests/php/unit/blocks/test-class-loader.php
@@ -74,7 +74,7 @@ class Test_Loader extends Abstract_Template {
 		$expected_filters = [
 			'enqueue_block_editor_assets',
 			'block_categories',
-			'plugins_loaded',
+			'init',
 		];
 
 		foreach ( $expected_filters as $filter ) {


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* As [suggested by Martin](https://wordpress.org/support/topic/can-priority-of-init-actions-be-reduced-for-taxonomies/), this allows calling `get_terms()` for custom taxonomies when calling `block_lab_add_field()`
* Custom taxonomies [should be registered on the init action](https://codex.wordpress.org/Function_Reference/register_taxonomy). So by moving `Loader:: retrieve_blocks()` from the `init` priority of  `1` to `10`, it gives a better opportunity for custom taxonomies to be registered, and ideally appear in `get_terms()`.
* The main requirement is that `block_lab_add_field()` is called before Block Lab calls `register_block_type()`. And this should be the case, as `do_action( 'block_lab_add_blocks' )` is right before `Loader::dynamic_block_loader()` runs.

#### Testing instructions
1. Add a new block and field
```php

add_action(
	'block_lab_add_blocks',
	static function() {
		block_lab_add_block(
			'test-email',
			[
				'title'    => __( 'Test Email', 'bl-testing' ),
				'category' => 'common',
				'icon'     => 'waves',
				'excluded' => [ 'page' ],
				'keywords' => [ 'example', 'foo' ],
			]
		);
		block_lab_add_field(
			'test-email',
			'email',
			[
				'label'   => 'Email here',
				'control' => 'email',
				'width'   => '25',
			]
		);
	}
);
```
2. Add a new post with the block
3. Enter an email in the field
4. Save and reload the page
5. Expected: the email entered still appears in the `<input>`
6. Add a template in the active theme, like `blocks/block-test-email.php`:
```php
<?php
/**
 * Template for test-email block.
 */

$field_name = 'email';
?>
<h1><?php echo esc_html( $field_name ) ; ?></h1>

<p class="<?php block_field( 'className' ); ?>"><?php esc_html_e( 'Here is the result of block_field(), this should be the email', 'bl-testing-templates' ); ?></p>
<span><?php block_field( $field_name ); ?></span>

<p><?php esc_html_e( 'And below is the result of block_value(), this should also be the email:', 'bl-testing-templates' ); ?></p>
<?php echo block_value( $field_name ); ?>
```
7. Expected: the email appears in the `<ServerSideRender>` and the front-end.
8. Add another block to the post that was created via the 'Edit Block' UI, not the PHP API
9. Verify that the values save and display on the front-end
