### PR TITLE
Make `block_field()` return `null` if second argument is `true`

### DIFF
--- a/php/helpers.php
+++ b/php/helpers.php
@@ -89,6 +89,8 @@ function block_field( $name, $echo = true ) {
 		 * and then output the field with a more suitable escaping function.
 		 */
 		echo wp_kses_post( $value );
+
+		return null;
 	}
 
 	return $value;

--- a/tests/php/integration/fixtures/all-fields-except-repeater.php
+++ b/tests/php/integration/fixtures/all-fields-except-repeater.php
@@ -74,7 +74,5 @@ foreach ( $non_string_fields as $name => $value ) :
 	endforeach;
 endforeach;
 
-printf(
-	'Here is the result of block_field() for multiselect: %s',
-	block_field( 'multiselect' )
-);
+echo 'Here is the result of block_field() for multiselect: ';
+block_field( 'multiselect' );

--- a/tests/php/unit/test-helpers.php
+++ b/tests/php/unit/test-helpers.php
@@ -87,7 +87,7 @@ class Test_Helpers extends \WP_UnitTestCase {
 
 		// Because block_field() has a second argument of true, this should echo the user login and return it.
 		$this->assertEquals( $mock_text, $actual_user_login );
-		$this->assertEquals( $return_value, $actual_user_login );
+		$this->assertEquals( null, $return_value );
 
 		ob_start();
 		$return_value = block_field( $class_key, true );
@@ -95,7 +95,7 @@ class Test_Helpers extends \WP_UnitTestCase {
 
 		// Test the same scenario as above, but for 'className'.
 		$this->assertEquals( $expected_class, $actual_class );
-		$this->assertEquals( $return_value, $actual_class );
+		$this->assertEquals( null, $return_value );
 
 		$additional_field_name  = 'example_additional_field';
 		$additional_field_value = 'Here is some text';
@@ -149,7 +149,7 @@ class Test_Helpers extends \WP_UnitTestCase {
 		$echoed_value = ob_get_clean();
 
 		// Now that the filter includes the additional field, the field should be echoed, even though it's not in block_lab()->data['config'].
-		$this->assertEquals( $additional_field_value, $return_value );
+		$this->assertEquals( null, $return_value );
 		$this->assertEquals( $additional_field_value, $echoed_value );
 	}
 

--- a/tests/php/unit/test-helpers.php
+++ b/tests/php/unit/test-helpers.php
@@ -85,7 +85,7 @@ class Test_Helpers extends \WP_UnitTestCase {
 		$return_value      = block_field( $field_name, true );
 		$actual_user_login = ob_get_clean();
 
-		// Because block_field() has a second argument of true, this should echo the user login and return it.
+		// Because block_field() has a second argument of true, this should echo the user login and return null.
 		$this->assertEquals( $mock_text, $actual_user_login );
 		$this->assertEquals( null, $return_value );
 


### PR DESCRIPTION
#### Changes
`block_field( 'foo' )` now returns `null`

#### Background
Before,  `block_field( 'foo' )` returned the same value that it echoed.

This can lead people to believe that it can be used to get the value.

For example:

```php
$text = block_field( 'example-text' );
if ( $text ) {
        echo '<p>' . esc_html( $text ) . '</p>';
}
```

...leads to output like:
```
Here is the text field<p>Here is the text field</p>
```

There have been some support topics about this:
https://wordpress.org/support/topic/variables-are-echoing-out/
https://wordpress.org/support/topic/php-block_field-name-of-field-does-not-display/


This won't fix those issues, as `block_value()` was usually needed instead of `block_field()`.

But it'll probably make it more clear from the beginning that `block_field( 'foo' )` shouldn't be used to get a value, only to echo. 

#### Testing instructions
1. Create a new post
2. Add a Block Lab block that has several fields
3. Ensure there's a template for the block that uses `block_field()`
4. Ensure the template still displays as expected in the `ServerSideRender` and the front-end
