### PR TITLE
Bump to 1.5.4, bump 'Tested up to' version to 5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog #
 
+### 1.5.4 – 2020-03-26 ###
+
+Improved stability, small bugfixes.
+
+* Fix: Now block_field() returns null if second argument is false, preventing confusion.
+* New: JavaScript component tests, improving reliability.
+* New: Linting for accessibility issues.
+
 ### 1.5.3 – 2020-01-20 ###
 
 Some UI improvements, bugfixes, and improved stability.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Improved stability, small bugfixes.
 
-* Fix: Now block_field() returns null if second argument is true, preventing confusion.
+* Fix: Now block_field() returns null if the second argument is true, preventing confusion.
 * New: JavaScript component tests, improving reliability.
 * New: Linting for accessibility issues.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Improved stability, small bugfixes.
 
-* Fix: Now block_field() returns null if second argument is false, preventing confusion.
+* Fix: Now block_field() returns null if second argument is true, preventing confusion.
 * New: JavaScript component tests, improving reliability.
 * New: Linting for accessibility issues.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Contributors: lukecarbis, ryankienstra, Stino11, rheinardkorf
 Tags: gutenberg, blocks, block editor, fields, template
 Requires at least: 5.0
-Tested up to: 5.3
+Tested up to: 5.4
 Requires PHP: 5.6
 Stable tag: trunk
 License: GPLv2 or later

--- a/block-lab.php
+++ b/block-lab.php
@@ -9,7 +9,7 @@
  * Plugin Name: Block Lab
  * Plugin URI: https://getblocklab.com
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.5.3
+ * Version: 1.5.4
  * Author: Block Lab
  * Author URI: https://getblocklab.com
  * License: GPL2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "block-lab",
   "title": "Block Lab",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "WordPress plugin with a simple templating system for building custom blocks.",
   "author": "Block Lab",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
#### Changes
* Bump BL version and 'Tested up to' version
* Add `CHANGELOG.md` entries

#### Testing instructions
* Regression testing already done for WP 5.4 in https://github.com/getblocklab/block-lab/issues/519#issuecomment-604214696
* A little more regression testing on 5.3.2 would be nice, though I did quick testing on this

Closes #519