### PR TITLE
Remove Upgrade screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,11 @@ Simple to use functions, ready to render and work with the values stored through
 ### Connect with Community ###
 Join The Lab, our free Block Lab Community on Slack. The Lab is our real-time home for sharing resources, learning, and making connections. [Learn more.](https://getblocklab.com/welcome-to-the-lab/)
 
-### Go Pro ###
-Block Lab Pro is here, with powerful features to take your block building to the next level. [Learn more.](https://getblocklab.com/block-lab-pro)
-
 ## Links ##
 * [WordPress.org](https://wordpress.org/plugins/block-lab)
 * [Github](https://github.com/getblocklab/block-lab)
 * [Documentation](https://getblocklab.com/docs)
 * [Support](https://wordpress.org/support/plugin/block-lab)
-* [Block Lab Pro](https://getblocklab.com/block-lab-pro)
 
 ## Installation ##
 ### From Within WordPress ###

--- a/css/admin.upgrade.css
+++ b/css/admin.upgrade.css
@@ -183,6 +183,7 @@
 	color: #000;
 	padding-top: 12px;
 	text-shadow: 0 0 4px #fff;
+	font-style: normal;
 }
 /* Tile sizing */
 .block-lab-pro .tile_2 {

--- a/php/admin/class-admin.php
+++ b/php/admin/class-admin.php
@@ -64,7 +64,7 @@ class Admin extends Component_Abstract {
 		$this->onboarding = new Onboarding();
 		block_lab()->register_component( $this->onboarding );
 
-		$show_pro_nag = apply_filters( 'block_lab_show_pro_nag', true );
+		$show_pro_nag = apply_filters( 'block_lab_show_pro_nag', false );
 		if ( $show_pro_nag && ! block_lab()->is_pro() ) {
 			$this->upgrade = new Upgrade();
 			block_lab()->register_component( $this->upgrade );

--- a/php/views/license.php
+++ b/php/views/license.php
@@ -73,14 +73,8 @@
 				} else {
 					echo wp_kses_post(
 						sprintf(
-							'<p>%1$s %2$s</p>',
-							__( 'No Pro license was found for this installation.', 'block-lab' ),
-							sprintf(
-								// translators: Opening and closing anchor and emphasis tags.
-								__( '%1$sGet Block Lab Pro!%2$s', 'block-lab' ),
-								'<a href="' . add_query_arg( [ 'page' => 'block-lab-pro' ] ) . '"><em>',
-								'</em></a>'
-							)
+							'<p>%1$s</p>',
+							__( 'No Pro license was found for this installation.', 'block-lab' )
 						)
 					);
 				}

--- a/php/views/license.php
+++ b/php/views/license.php
@@ -74,7 +74,7 @@
 					echo wp_kses_post(
 						sprintf(
 							'<p>%1$s</p>',
-							__( 'No Pro license was found for this installation.', 'block-lab' )
+							__( 'No license was found for this installation.', 'block-lab' )
 						)
 					);
 				}

--- a/php/views/upgrade.php
+++ b/php/views/upgrade.php
@@ -13,55 +13,13 @@
 		<div class="tile_body">
 			<div>
 				<h1>Block Lab <span class="pro-pill">Pro</span></h1>
-				<p class="description"><?php esc_html_e( 'A custom block building experience perfect for agencies and freelancers.', 'block-lab' ); ?></p>
-				<div class="cta_license_form_wrapper">
-					<form class="license_key_form" method="post" action="options.php">
-						<?php
-						register_setting( 'block-lab-license-key', 'block_lab_license_key' );
-						settings_fields( 'block-lab-license-key' );
-						?>
-						<input class="input_text" placeholder="Enter license key" name="block_lab_license_key" type="text" />
-						<input class="button" type="submit" value="<?php esc_html_e( 'Activate', 'block-lab' ); ?>" />
-					</form>
-					<p class="license_key_text">or</p>
-					<a target="_blank" class="button button--secondary button_cta" href="https://getblocklab.com/block-lab-pro"><?php esc_html_e( 'Go Pro', 'block-lab' ); ?></a>
-				</div>
+				<p class="description"><?php esc_html_e( '…is no longer available. 😢', 'block-lab' ); ?></p>
 			</div>
 		</div>
 	</div>
 	<!-- Dashboard Tile -->
-	<div class="tile tile_2">
-		<div class="tile_header">
-			<div class="tile_icon_wrapper" style="background-image: url('https://getblocklab.com/wp-content/uploads/2019/02/block_lab_admin_icon_new_fields.svg');"></div>
-		</div>
-		<div class="tile_body">
-			<h4 class="align_center"><?php esc_html_e( 'Pro Fields', 'block-lab' ); ?></h4>
-			<p class="align_center"><?php esc_html_e( 'More fields including repeater, post object, and more to help you build the custom blocks you need for yourself and your clients.', 'block-lab' ); ?></p>
-		</div>
-	</div>
-	<!-- Dashboard Tile -->
-	<div class="tile tile_2">
-		<div class="tile_header">
-			<div class="tile_icon_wrapper" style="background-image: url('https://getblocklab.com/wp-content/uploads/2019/02/block_lab_admin_icon_features.svg');"></div>
-		</div>
-		<div class="tile_body">
-			<h4 class="align_center"><?php esc_html_e( 'Pro Features', 'block-lab' ); ?></h4>
-			<p class="align_center"><?php esc_html_e( 'Features including conditional logic, custom validation, and white-labeling, to help you extend Block Lab and leverage the best of Gutenberg.', 'block-lab' ); ?></p>
-		</div>
-	</div>
-	<!-- Dashboard Tile -->
-	<div class="tile tile_2">
-		<div class="tile_header">
-			<div class="tile_icon_wrapper" style="background-image: url('https://getblocklab.com/wp-content/uploads/2019/02/block_lab_admin_icon_support.svg');"></div>
-		</div>
-		<div class="tile_body">
-			<h4 class="align_center"><?php esc_html_e( 'Pro Support', 'block-lab' ); ?></h4>
-			<p class="align_center"><?php esc_html_e( 'Priority support and regular feature updates. We’re right here for you whenever you have a question.', 'block-lab' ); ?></p>
-		</div>
-	</div>
-	<!-- Dashboard Tile -->
 	<div class="tile tile_3">
-	<div class="tile_body">
+		<div class="tile_body">
 			<h4><?php esc_html_e( '★★ Loving Block Lab? ★★', 'block-lab' ); ?></h4>
 			<p><?php esc_html_e( 'If Block Lab has helped you build amazing custom blocks for your site, leave us a review on WordPress.org.', 'block-lab' ); ?></p>
 			<a class="button" target="_blank" href="https://wordpress.org/plugins/block-lab/#reviews"><?php esc_html_e( '★ Leave Review ★', 'block-lab' ); ?></a>
@@ -69,7 +27,7 @@
 	</div>
 	<!-- Dashboard Tile -->
 	<div class="tile tile_3">
-	<div class="tile_body">
+		<div class="tile_body">
 			<h4><?php esc_html_e( 'Get more out of Block Lab', 'block-lab' ); ?></h4>
 			<p><?php esc_html_e( 'Subscribe to our newsletter for news, updates, and tutorials on working with Gutenberg.', 'block-lab' ); ?></p>
 		</div>

--- a/tests/php/unit/admin/test-class-admin.php
+++ b/tests/php/unit/admin/test-class-admin.php
@@ -73,12 +73,6 @@ class Test_Admin extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( $settings_class, $components_value );
 		$this->assertArrayHasKey( $license_class, $components_value );
 
-		// Because the Pro license isn't active, there should be an Upgrade class instantiated.
-		$upgrade_class = 'Block_Lab\Admin\Upgrade';
-		$this->assertEquals( $upgrade_class, get_class( $this->instance->upgrade ) );
-		$this->assertArrayHasKey( $upgrade_class, $components_value );
-		$this->assertFalse( $this->did_settings_redirect_occur() );
-
 		// With an active Pro license, this should redirect from the Pro page to the settings page.
 		$this->set_license_validity( true );
 		Monkey\Functions\expect( 'filter_input' )


### PR DESCRIPTION
#### Changes
* Upgrade screen is hidden by default
* If the upgrade screen is filtered on intentionally, it now shows a "Not available" message.

#### Testing instructions
1. Remove your Pro license key (if you've got one)
2. Check that there's no "Go Pro" item in the menu
3. Filter `block_lab_show_pro_nag` to return `true`
4. Make sure there's no "upgrade" messaging on the Go Pro screen

#### Note
I didn't just pull the Upgrade class out entirely, because I didn't want to have to deprecate the `block_lab_show_pro_nag` filter. The class might be useful in some other context.

![Screen Shot 2020-04-22 at 1 23 58 pm](https://user-images.githubusercontent.com/1097667/79937186-8a671f00-849c-11ea-996b-e5aa56330153.jpg)
(This screen is no longer accessible by default)