### PR TITLE
Bump the version of BL to 1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog #
 
+### 1.5.5 – 2020-04-23 ###
+
+Removed upgrade screen, dependency updates
+
+* Tweak: By default, the upgrade screen is hidden
+* Tweak: Minor package.json dependency updates for security and reliability
+
 ### 1.5.4 – 2020-03-26 ###
 
 Improved stability, small bugfixes.

--- a/block-lab.php
+++ b/block-lab.php
@@ -9,7 +9,7 @@
  * Plugin Name: Block Lab
  * Plugin URI: https://getblocklab.com
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.5.4
+ * Version: 1.5.5
  * Author: Block Lab
  * Author URI: https://getblocklab.com
  * License: GPL2

--- a/js/blocks/components/test/fetch-input.js
+++ b/js/blocks/components/test/fetch-input.js
@@ -67,12 +67,12 @@ describe( 'FetchInput', () => {
 		[ [ 'a-result' ], false ],
 		[ [ 'first-result', 'another-result' ], false ],
 	] )( 'should only have the error class if there are no results after focusing',
-		( apiResults, expected ) => {
+		async ( apiResults, expected ) => {
 			apiFetch.mockImplementationOnce( () => new Promise( ( resolve ) => resolve( apiResults ) ) );
 			const { input } = setup( baseProps );
 			fireEvent.focus( input );
 
-			waitForDomChange( { container: input } ).then( () => {
+			await waitForDomChange( { container: input } ).then( () => {
 				expect( input.classList.contains( 'text-control__error' ) ).toStrictEqual( expected );
 			} );
 		}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "block-lab",
   "title": "Block Lab",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "WordPress plugin with a simple templating system for building custom blocks.",
   "author": "Block Lab",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
 
#### Changes
* Bumps the version to `1.5.5`
* [Here's the diff](https://github.com/getblocklab/block-lab/compare/8192f11dbdd71eeadc29c272c6f34c2adf9b2716...64283d6ce3c7ce5b4c87d4c5ad5102bae55fe8d0) since the last version bump (until https://github.com/getblocklab/block-lab/pull/538 is merged)

#### Testing instructions
1. Create a new block
2. Add a BL block with all fields
3. Do regression testing, especially for Post, Taxonomy, and User fields
