### PR TITLE
Migrate `block-lab` namespace in `post_content`

### DIFF
--- a/php/blocks/migration/class-post-content.php
+++ b/php/blocks/migration/class-post-content.php
@@ -86,7 +86,10 @@ class Post_Content {
 	public function migrate_single( $post_id ) {
 		$post = get_post( $post_id );
 		if ( ! isset( $post->ID ) ) {
-			return new WP_Error( 'Invalid post ID' );
+			return new WP_Error(
+				'invalid_post_id',
+				__( 'Invalid post ID', 'block-lab' )
+			);
 		}
 
 		$replacement_count = 0;
@@ -99,7 +102,10 @@ class Post_Content {
 		);
 
 		if ( 0 === $replacement_count ) {
-			return new WP_Error( 'Post content did not have blocks with the namespace' );
+			return new WP_Error(
+				'no_block_namespace_found',
+				__( 'Post content did not have blocks with the namespace', 'block-lab' )
+			);
 		}
 
 		return wp_update_post(

--- a/php/blocks/migration/class-post-content.php
+++ b/php/blocks/migration/class-post-content.php
@@ -15,6 +15,7 @@ use WP_Error;
  * Class Post_Content
  */
 class Post_Content {
+
 	/**
 	 * The previous namespace of the block.
 	 *
@@ -32,8 +33,8 @@ class Post_Content {
 	/**
 	 * Post_Content constructor.
 	 *
-	 * @param string $previous_block_namespace  Previous namespace of the blocks.
-	 * @param string $new_block_namespace       New namespace of the blocks.
+	 * @param string $previous_block_namespace Previous namespace of the blocks.
+	 * @param string $new_block_namespace      New namespace of the blocks.
 	 */
 	public function __construct( $previous_block_namespace, $new_block_namespace ) {
 		$this->previous_block_namespace = $previous_block_namespace;

--- a/php/blocks/migration/class-post-content.php
+++ b/php/blocks/migration/class-post-content.php
@@ -77,6 +77,7 @@ class Post_Content {
 		if ( ! isset( $post->ID ) ) {
 			return new WP_Error( 'Invalid post ID' );
 		}
+
 		$new_post_content = preg_replace(
 			'#(<!--\s+wp:)(' . sanitize_key( $this->previous_block_namespace ) . ')(/[a-z][a-z0-9_-]*)#s',
 			'$1' . sanitize_key( $this->new_block_namespace ) . '$3',

--- a/php/blocks/migration/class-post-content.php
+++ b/php/blocks/migration/class-post-content.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Post_Content.
+ *
+ * @package   Block_Lab
+ * @copyright Copyright(c) 2020, Block Lab
+ * @license http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
+ */
+
+namespace Block_Lab\Blocks\Migration;
+
+use WP_Post;
+
+/**
+ * Class Post_Content
+ */
+class Post_Content {
+	/**
+	 * The previous namespace of the block.
+	 *
+	 * @var string
+	 */
+	private $previous_block_namespace;
+
+	/**
+	 * The new namespace of the block.
+	 *
+	 * @var string
+	 */
+	private $new_block_namespace;
+
+	/**
+	 * Post_Content constructor.
+	 *
+	 * @param string $previous_block_namespace  Previous namespace of the blocks.
+	 * @param string $new_block_namespace       New namespace of the blocks.
+	 */
+	public function __construct( $previous_block_namespace, $new_block_namespace ) {
+		$this->previous_block_namespace = $previous_block_namespace;
+		$this->new_block_namespace      = $new_block_namespace;
+	}
+
+	/**
+	 * Migrates the block namespaces in post_content.
+	 *
+	 * Blocks are stored in the post_content of a post with a namespace,
+	 * like '<!-- wp:block-lab/test-image {"example-image":8} /-->'.
+	 * In that case, 'block-lab' needs to be changed to the new namespace.
+	 * But nothing else in the block should be changed.
+	 * The block pattern is mainly taken from Gutenberg.
+	 *
+	 * @see https://github.com/WordPress/wordpress-develop/blob/78d1ab2ed40093a5bd2a75b01ceea37811739f55/src/wp-includes/class-wp-block-parser.php#L413
+	 *
+	 * @param WP_Post $post The post to convert.
+	 * @return int|
+	 * On success: the post ID that was changed, on failure: 0 or WP_Error.
+	 */
+	public function migrate_single( WP_Post $post ) {
+		$new_post_content = preg_replace(
+			'#(<!--\s+wp:)(' . sanitize_key( $this->previous_block_namespace ) . ')(/[a-z][a-z0-9_-]*)#s',
+			'$1' . sanitize_key( $this->new_block_namespace ) . '$3',
+			$post->post_content
+		);
+
+		return wp_update_post(
+			[
+				'ID'           => $post->ID,
+				'post_content' => $new_post_content,
+			]
+		);
+	}
+}

--- a/php/blocks/migration/class-post-content.php
+++ b/php/blocks/migration/class-post-content.php
@@ -53,7 +53,7 @@ class Post_Content {
 	 * @see https://github.com/WordPress/wordpress-develop/blob/78d1ab2ed40093a5bd2a75b01ceea37811739f55/src/wp-includes/class-wp-block-parser.php#L413
 	 *
 	 * @param WP_Post $post The post to convert.
-	 * @return int|WP_Error On success: the post ID that was changed, on failure: 0 or WP_Error.
+	 * @return int|WP_Error The post ID that was changed, or a WP_Error on failure.
 	 */
 	public function migrate_single( WP_Post $post ) {
 		$new_post_content = preg_replace(
@@ -65,8 +65,9 @@ class Post_Content {
 		return wp_update_post(
 			[
 				'ID'           => $post->ID,
-				'post_content' => $new_post_content,
-			]
+				'post_content' => wp_slash( $new_post_content ),
+			],
+			true
 		);
 	}
 }

--- a/php/blocks/migration/class-post-content.php
+++ b/php/blocks/migration/class-post-content.php
@@ -102,9 +102,8 @@ class Post_Content {
 	/**
 	 * Gets posts that have Block Lab blocks in their post_content.
 	 *
-	 * The queries for the posts that have wp:block-lab/ in the post content,
+	 * Queries for the posts that have wp:block-lab/ in the post content,
 	 * meaning they probably have a Block Lab block.
-	 * This doesn't query for every post that can possibly have a block.
 	 *
 	 * @return array The posts that were found.
 	 */

--- a/php/blocks/migration/class-post-content.php
+++ b/php/blocks/migration/class-post-content.php
@@ -47,13 +47,19 @@ class Post_Content {
 	 * @return array The results of migration, either int or WP_Error.
 	 */
 	public function migrate_all() {
-		$posts   = $this->query_for_posts();
-		$results = [];
+		$results            = [];
+		$error_count        = 0;
+		$max_allowed_errors = 20;
+		$posts              = $this->query_for_posts();
 
-		while ( $posts ) {
+		while ( $posts && $error_count < $max_allowed_errors ) {
 			foreach ( $posts as $post ) {
 				if ( isset( $post->ID ) ) {
-					$results[] = $this->migrate_single( $post->ID );
+					$migrated_post = $this->migrate_single( $post->ID );
+					$results[]     = $migrated_post;
+					if ( is_wp_error( $migrated_post ) ) {
+						$error_count++;
+					}
 				}
 			}
 

--- a/php/blocks/migration/class-post-content.php
+++ b/php/blocks/migration/class-post-content.php
@@ -10,6 +10,7 @@
 namespace Block_Lab\Blocks\Migration;
 
 use WP_Post;
+use WP_Error;
 
 /**
  * Class Post_Content
@@ -52,8 +53,7 @@ class Post_Content {
 	 * @see https://github.com/WordPress/wordpress-develop/blob/78d1ab2ed40093a5bd2a75b01ceea37811739f55/src/wp-includes/class-wp-block-parser.php#L413
 	 *
 	 * @param WP_Post $post The post to convert.
-	 * @return int|
-	 * On success: the post ID that was changed, on failure: 0 or WP_Error.
+	 * @return int|WP_Error On success: the post ID that was changed, on failure: 0 or WP_Error.
 	 */
 	public function migrate_single( WP_Post $post ) {
 		$new_post_content = preg_replace(

--- a/php/blocks/migration/class-post-content.php
+++ b/php/blocks/migration/class-post-content.php
@@ -78,11 +78,18 @@ class Post_Content {
 			return new WP_Error( 'Invalid post ID' );
 		}
 
-		$new_post_content = preg_replace(
+		$replacement_count = 0;
+		$new_post_content  = preg_replace(
 			'#(<!--\s+wp:)(' . sanitize_key( $this->previous_block_namespace ) . ')(/[a-z][a-z0-9_-]*)#s',
 			'$1' . sanitize_key( $this->new_block_namespace ) . '$3',
-			$post->post_content
+			$post->post_content,
+			-1,
+			$replacement_count
 		);
+
+		if ( 0 === $replacement_count ) {
+			return new WP_Error( 'Post content did not have blocks with the namespace' );
+		}
 
 		return wp_update_post(
 			[

--- a/php/blocks/migration/class-post-content.php
+++ b/php/blocks/migration/class-post-content.php
@@ -9,7 +9,6 @@
 
 namespace Block_Lab\Blocks\Migration;
 
-use WP_Post;
 use WP_Error;
 
 /**

--- a/tests/bin/migrate-post-content.php
+++ b/tests/bin/migrate-post-content.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Migrates the entire site's post content to the new namespace.
+ *
+ * For testing, do not use in production.
+ *
+ * @package Block_Lab\Cli
+ */
+
+namespace Block_Lab\Cli;
+
+use WP_CLI;
+use Exception;
+use Block_Lab\Blocks\Migration\Post_Content;
+
+/**
+ * Migrates all of the post content to the new namespace.
+ *
+ * Only for testing, not production.
+ * Formats the results in a WP-CLI table.
+ */
+function migrate_all_post_content() {
+	WP_CLI::confirm( 'Are you sure you want to migrate all of your site content to the new block namespace?' );
+
+	$results       = ( new Post_Content( 'block-lab', 'genesis-custom-blocks' ) )->migrate_all();
+	$success_posts = array_filter(
+		$results,
+		static function( $result ) {
+			return is_int( $result );
+		}
+	);
+	$error_posts   = array_filter(
+		$results,
+		static function( $result ) {
+			return is_wp_error( $result );
+		}
+	);
+
+	if ( empty( $error_posts ) ) {
+		WP_CLI::success(
+			sprintf(
+				'%d posts were migrated successfully',
+				count( $success_posts )
+			)
+		);
+	} else {
+		WP_CLI::warning(
+			sprintf(
+				'%d posts were migrated successfully, and %d had errors',
+				count( $success_posts ),
+				count( $error_posts )
+			)
+		);
+
+		WP_CLI::line( 'Error messages:' );
+		foreach ( $error_posts as $error_post ) {
+			WP_CLI::line( $error_post->get_error_code() );
+		}
+	}
+
+	$key_post_id   = 'Post ID';
+	$key_post_type = 'Post type';
+	$key_revision  = 'Revision';
+
+	$table_results = [];
+	foreach ( $success_posts as $post_id ) {
+		$table_results[] = [
+			$key_post_id   => $post_id,
+			$key_post_type => get_post_type( $post_id ),
+			$key_revision  => get_revision_link( $post_id ),
+		];
+	}
+
+	WP_CLI::line( "\nMigrated successfully: \n" );
+	WP_CLI\Utils\format_items(
+		'table',
+		$table_results,
+		[ $key_post_id, $key_post_type, $key_revision ]
+	);
+}
+
+/**
+ * Gets the link to the WP revision UI.
+ *
+ * Mainly taken from includes/meta-box.php
+ *
+ * @param int $post_id The ID of the post.
+ * @return string|false The link to the revision UI, or false if there is no revision available.
+ */
+function get_revision_link( $post_id ) {
+	$revisions = wp_get_post_revisions( $post_id );
+	if ( empty( $revisions ) ) {
+		return false;
+	}
+
+	reset( $revisions ); // Reset the pointer.
+
+	return add_query_arg(
+		[
+			'revision' => key( $revisions ),
+		],
+		admin_url( 'revision.php' )
+	);
+}
+
+if ( ! defined( 'WP_CLI' ) ) {
+	echo "Please run this with WP-CLI via: wp eval-file tests/bin/migrate-post-content.php\n";
+	exit( 1 );
+}
+
+// Run the script.
+try {
+	migrate_all_post_content();
+} catch ( Exception $e ) {
+	WP_CLI::error( $e->getMessage() );
+}

--- a/tests/php/integration/test-repeater-template-output.php
+++ b/tests/php/integration/test-repeater-template-output.php
@@ -182,9 +182,9 @@ class Test_Repeater_Template_Output extends Abstract_Attribute {
 	 *
 	 * @covers \block_rows()
 	 * @covers \block_row()
-	 * @covers \reset_block_row()
-	 * @covers \block_row_field()
-	 * @covers \block_row_value()
+	 * @covers \reset_block_rows()
+	 * @covers \block_sub_field()
+	 * @covers \block_sub_value()
 	 * @covers \block_row_index()
 	 * @covers \block_row_count()
 	 */

--- a/tests/php/unit/blocks/migration/test-class-post-content.php
+++ b/tests/php/unit/blocks/migration/test-class-post-content.php
@@ -208,6 +208,16 @@ class Test_Post_Content extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test migrate_single with an invalid post ID.
+	 *
+	 * @covers \Block_Lab\Blocks\Migration\Post_Content::migrate_single()
+	 */
+	public function test_migrate_single_invalid_post_id() {
+		$invalid_post_id = 5000000000;
+		$this->assertEquals( 'WP_Error', get_class( $this->instance->migrate_single( $invalid_post_id ) ) );
+	}
+
+	/**
 	 * Test migrate_all.
 	 *
 	 * @covers \Block_Lab\Blocks\Migration\Post_Content::migrate_all()

--- a/tests/php/unit/blocks/migration/test-class-post-content.php
+++ b/tests/php/unit/blocks/migration/test-class-post-content.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Test_Post_Content
+ *
+ * @package Block_Lab
+ */
+
+use Block_Lab\Blocks\Migration\Post_Content;
+
+/**
+ * Class Test_Post_Content
+ *
+ * @package Block_Lab
+ */
+class Test_Post_Content extends WP_UnitTestCase {
+
+	/**
+	 * The previous namespace of the block.
+	 *
+	 * @var string
+	 */
+	const PREVIOUS_BLOCK_NAMESPACE = 'block-lab';
+
+	/**
+	 * The new namespace of the block.
+	 *
+	 * @var string
+	 */
+	const NEW_BLOCK_NAMESPACE = 'genesis-custom-blocks';
+
+	/**
+	 * The instance to test.
+	 *
+	 * @var Post_Content
+	 */
+	public $instance;
+
+	/**
+	 * Initial content for a simple block.
+	 *
+	 * @var string
+	 */
+	public $image_block_initial_content = '<!-- wp:block-lab/test-image {"image":154} /-->';
+
+	/**
+	 * Expected content for a simple block.
+	 *
+	 * @var string
+	 */
+	public $image_block_expected_content = '<!-- wp:genesis-custom-blocks/test-image {"image":154} /-->';
+
+	/**
+	 * Initial content for two blocks.
+	 *
+	 * @var string
+	 */
+	public $two_blocks_initial_content = '<!-- wp:block-lab/test-textarea {"textarea":"Here is some text And some more"} /-->
+		<!-- wp:block-lab/test-range {"range":32} /-->';
+
+	/**
+	 * Expected content for two blocks.
+	 *
+	 * @var string
+	 */
+	public $two_blocks_expected_content = '<!-- wp:genesis-custom-blocks/test-textarea {"textarea":"Here is some text And some more"} /-->
+		<!-- wp:genesis-custom-blocks/test-range {"range":32} /-->';
+
+	/**
+	 * Sets up each test.
+	 *
+	 * @inheritDoc
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->instance = new Post_Content( self::PREVIOUS_BLOCK_NAMESPACE, self::NEW_BLOCK_NAMESPACE );
+	}
+
+	/**
+	 * Creates a block post with the previous post_type.
+	 *
+	 * @param string $content   The post content.
+	 * @param string $post_type The post_type.
+	 * @return WP_Post The post with the content.
+	 */
+	public function create_block_post( $content, $post_type = 'post' ) {
+		return $this->factory()->post->create_and_get(
+			[
+				'post_type'    => $post_type,
+				'post_content' => $content,
+			]
+		);
+	}
+
+	/**
+	 * Gets the test data for test_migrate_single().
+	 *
+	 * @return array The test data.
+	 */
+	public function get_data_migrate_single() {
+		return [
+			'no_block'           => [
+				'This post content does not have a block <p>Here is a paragraph</p>',
+			],
+			'simple_image_block' => [
+				$this->image_block_initial_content,
+				$this->image_block_expected_content,
+			],
+			'two_blocks'         => [
+				$this->two_blocks_initial_content,
+				$this->two_blocks_expected_content,
+			],
+		];
+	}
+
+	/**
+	 * Test migrate_single.
+	 *
+	 * @dataProvider get_data_migrate_single
+	 * @covers \Block_Lab\Blocks\Migration\Post_Content::migrate_single()
+	 *
+	 * @param string $initial_post_content  Initial post_content.
+	 * @param string $expected_post_content Expected post_content of the new post.
+	 */
+	public function test_migrate_single( $initial_post_content, $expected_post_content = null ) {
+		if ( null === $expected_post_content ) {
+			$expected_post_content = $initial_post_content;
+		}
+
+		$post = $this->create_block_post( $initial_post_content );
+		$this->assertInternalType( 'int', $this->instance->migrate_single( $post ) );
+
+		$new_post = get_post( $post->ID );
+		$this->assertEquals( $expected_post_content, $new_post->post_content );
+	}
+}

--- a/tests/php/unit/blocks/migration/test-class-post-content.php
+++ b/tests/php/unit/blocks/migration/test-class-post-content.php
@@ -140,7 +140,7 @@ class Test_Post_Content extends WP_UnitTestCase {
 
 					<!-- wp:group -->
 					<div class="wp-block-group"><div class="wp-block-group__inner-container"><!-- wp:image {"id":149,"sizeSlug":"large"} -->
-					<figure class="wp-block-image size-large"><img src="https://bl.test/wp-content/uploads/2020/01/858-600x400-1.jpg" alt="" class="wp-image-149"/></figure>
+					<figure class="wp-block-image size-large"><img src="https://block.test/wp-content/uploads/2020/01/858-600x400-1.jpg" alt="" class="wp-image-149"/></figure>
 					<!-- /wp:image --></div></div>
 					<!-- /wp:group -->
 					
@@ -151,7 +151,7 @@ class Test_Post_Content extends WP_UnitTestCase {
 
 					<!-- wp:group -->
 					<div class="wp-block-group"><div class="wp-block-group__inner-container"><!-- wp:image {"id":149,"sizeSlug":"large"} -->
-					<figure class="wp-block-image size-large"><img src="https://bl.test/wp-content/uploads/2020/01/858-600x400-1.jpg" alt="" class="wp-image-149"/></figure>
+					<figure class="wp-block-image size-large"><img src="https://block.test/wp-content/uploads/2020/01/858-600x400-1.jpg" alt="" class="wp-image-149"/></figure>
 					<!-- /wp:image --></div></div>
 					<!-- /wp:group -->
 					
@@ -165,7 +165,7 @@ class Test_Post_Content extends WP_UnitTestCase {
 					<!-- wp:archives /-->
 
 					<!-- wp:gallery {"ids":[154,147,148]} -->
-					<figure class="wp-block-gallery columns-3 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://bl.test/wp-content/uploads/2020/01/979-200x400-2.jpg" alt="" data-id="154" data-full-url="https://bl.test/wp-content/uploads/2020/01/979-200x400-2.jpg" data-link="https://bl.test/?attachment_id=154" class="wp-image-154"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://bl.test/wp-content/uploads/2020/01/568-1000x1000-1.jpg" alt="" data-id="147" data-full-url="https://bl.test/wp-content/uploads/2020/01/568-1000x1000-1.jpg" data-link="https://bl.test/?attachment_id=147" class="wp-image-147"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://bl.test/wp-content/uploads/2020/01/726-300x300-1.jpg" alt="" data-id="148" data-full-url="https://bl.test/wp-content/uploads/2020/01/726-300x300-1.jpg" data-link="https://bl.test/?attachment_id=148" class="wp-image-148"/></figure></li></ul></figure>
+					<figure class="wp-block-gallery columns-3 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://block.test/wp-content/uploads/2020/01/979-200x400-2.jpg" alt="" data-id="154" data-full-url="https://block.test/wp-content/uploads/2020/01/979-200x400-2.jpg" data-link="https://block.test/?attachment_id=154" class="wp-image-154"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://block.test/wp-content/uploads/2020/01/568-1000x1000-1.jpg" alt="" data-id="147" data-full-url="https://block.test/wp-content/uploads/2020/01/568-1000x1000-1.jpg" data-link="https://block.test/?attachment_id=147" class="wp-image-147"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://block.test/wp-content/uploads/2020/01/726-300x300-1.jpg" alt="" data-id="148" data-full-url="https://block.test/wp-content/uploads/2020/01/726-300x300-1.jpg" data-link="https://block.test/?attachment_id=148" class="wp-image-148"/></figure></li></ul></figure>
 					<!-- /wp:gallery -->
 
 					<!-- wp:block-lab/test-post-2 {"post":{"id":606,"name":"Testing"}} /-->
@@ -176,7 +176,7 @@ class Test_Post_Content extends WP_UnitTestCase {
 					<!-- wp:archives /-->
 
 					<!-- wp:gallery {"ids":[154,147,148]} -->
-					<figure class="wp-block-gallery columns-3 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://bl.test/wp-content/uploads/2020/01/979-200x400-2.jpg" alt="" data-id="154" data-full-url="https://bl.test/wp-content/uploads/2020/01/979-200x400-2.jpg" data-link="https://bl.test/?attachment_id=154" class="wp-image-154"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://bl.test/wp-content/uploads/2020/01/568-1000x1000-1.jpg" alt="" data-id="147" data-full-url="https://bl.test/wp-content/uploads/2020/01/568-1000x1000-1.jpg" data-link="https://bl.test/?attachment_id=147" class="wp-image-147"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://bl.test/wp-content/uploads/2020/01/726-300x300-1.jpg" alt="" data-id="148" data-full-url="https://bl.test/wp-content/uploads/2020/01/726-300x300-1.jpg" data-link="https://bl.test/?attachment_id=148" class="wp-image-148"/></figure></li></ul></figure>
+					<figure class="wp-block-gallery columns-3 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://block.test/wp-content/uploads/2020/01/979-200x400-2.jpg" alt="" data-id="154" data-full-url="https://block.test/wp-content/uploads/2020/01/979-200x400-2.jpg" data-link="https://block.test/?attachment_id=154" class="wp-image-154"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://block.test/wp-content/uploads/2020/01/568-1000x1000-1.jpg" alt="" data-id="147" data-full-url="https://block.test/wp-content/uploads/2020/01/568-1000x1000-1.jpg" data-link="https://block.test/?attachment_id=147" class="wp-image-147"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://block.test/wp-content/uploads/2020/01/726-300x300-1.jpg" alt="" data-id="148" data-full-url="https://block.test/wp-content/uploads/2020/01/726-300x300-1.jpg" data-link="https://block.test/?attachment_id=148" class="wp-image-148"/></figure></li></ul></figure>
 					<!-- /wp:gallery -->
 
 					<!-- wp:genesis-custom-blocks/test-post-2 {"post":{"id":606,"name":"Testing"}} /-->

--- a/tests/php/unit/blocks/migration/test-class-post-content.php
+++ b/tests/php/unit/blocks/migration/test-class-post-content.php
@@ -119,9 +119,13 @@ class Test_Post_Content extends WP_UnitTestCase {
 		return [
 			'no_block'                               => [
 				'This post content does not have a block <p>Here is a paragraph</p>',
+				null,
+				'object', // This should return a WP_Error.
 			],
 			'unrelated_blocks_are_not_affected'      => [
 				$this->unrelated_blocks,
+				null,
+				'object',
 			],
 			'simple_image_block'                     => [
 				$this->image_block_initial_content,
@@ -190,8 +194,9 @@ class Test_Post_Content extends WP_UnitTestCase {
 	 *
 	 * @param string $initial_post_content  Initial post_content.
 	 * @param string $expected_post_content Expected post_content of the new post.
+	 * @param string $expected_return_type  Expected return type of the tested method.
 	 */
-	public function test_migrate_single( $initial_post_content, $expected_post_content = null ) {
+	public function test_migrate_single( $initial_post_content, $expected_post_content = null, $expected_return_type = 'int' ) {
 		// Prevent sanitization of post_content.
 		remove_filter( 'content_save_pre', 'wp_filter_post_kses' );
 
@@ -201,7 +206,7 @@ class Test_Post_Content extends WP_UnitTestCase {
 
 		$post_id      = $this->create_block_post( $initial_post_content );
 		$return_value = $this->instance->migrate_single( $post_id );
-		$this->assertInternalType( 'int', $return_value );
+		$this->assertInternalType( $expected_return_type, $return_value );
 
 		$new_post = get_post( $post_id );
 		$this->assertEquals( $expected_post_content, $new_post->post_content );

--- a/tests/php/unit/blocks/migration/test-class-post-content.php
+++ b/tests/php/unit/blocks/migration/test-class-post-content.php
@@ -86,7 +86,7 @@ class Test_Post_Content extends WP_UnitTestCase {
 		return $this->factory()->post->create_and_get(
 			[
 				'post_type'    => $post_type,
-				'post_content' => $content,
+				'post_content' => wp_slash( $content ),
 			]
 		);
 	}
@@ -98,16 +98,79 @@ class Test_Post_Content extends WP_UnitTestCase {
 	 */
 	public function get_data_migrate_single() {
 		return [
-			'no_block'           => [
+			'no_block'                               => [
 				'This post content does not have a block <p>Here is a paragraph</p>',
 			],
-			'simple_image_block' => [
+			'no_block_lab_block'                     => [
+				'<!-- wp:image {"id":145,"sizeSlug":"large"} -->
+					<figure class="wp-block-image size-large"><img src="https://example.test/wp-content/uploads/2020/01/81-600x400-1.jpg" alt="" class="wp-image-145" /></figure>
+					<!-- /wp:image -->
+
+					<!-- wp:paragraph -->
+					<p>Here is some text</p>
+					<!-- /wp:paragraph -->
+
+					<!-- wp:core-embed/youtube {"url":"https://www.youtube.com/watch?v=gS6_xOABTWo","type":"video","providerNameSlug":"youtube","className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+					<figure class="wp-block-embed-youtube wp-block-embed is-type-video is-provider-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+					https://www.youtube.com/watch?v=gS6_xOABTWo
+					</div></figure>
+					<!-- /wp:core-embed/youtube -->',
+			],
+			'simple_image_block'                     => [
 				$this->image_block_initial_content,
 				$this->image_block_expected_content,
 			],
-			'two_blocks'         => [
+			'two_blocks'                             => [
 				$this->two_blocks_initial_content,
 				$this->two_blocks_expected_content,
+			],
+			'single_block_lab_block_among_others'    => [
+				'<!-- wp:block-lab/repeater-with-classic {"repeater":{"rows":[{"":"","classic":"\u003cp\u003eHere is a classic text field\u003c/p\u003e\n\u003cp\u003eAnd another line\u003c/p\u003e"},{"":"","classic":"\u003cp\u003eHere is another\u003c/p\u003e"}]}} /-->
+
+					<!-- wp:group -->
+					<div class="wp-block-group"><div class="wp-block-group__inner-container"><!-- wp:image {"id":149,"sizeSlug":"large"} -->
+					<figure class="wp-block-image size-large"><img src="https://bl.test/wp-content/uploads/2020/01/858-600x400-1.jpg" alt="" class="wp-image-149"/></figure>
+					<!-- /wp:image --></div></div>
+					<!-- /wp:group -->
+					
+					<!-- wp:button -->
+					<div class="wp-block-button"><a class="wp-block-button__link" href="https://example.com">Click here</a></div>
+					<!-- /wp:button -->',
+				'<!-- wp:genesis-custom-blocks/repeater-with-classic {"repeater":{"rows":[{"":"","classic":"\u003cp\u003eHere is a classic text field\u003c/p\u003e\n\u003cp\u003eAnd another line\u003c/p\u003e"},{"":"","classic":"\u003cp\u003eHere is another\u003c/p\u003e"}]}} /-->
+
+					<!-- wp:group -->
+					<div class="wp-block-group"><div class="wp-block-group__inner-container"><!-- wp:image {"id":149,"sizeSlug":"large"} -->
+					<figure class="wp-block-image size-large"><img src="https://bl.test/wp-content/uploads/2020/01/858-600x400-1.jpg" alt="" class="wp-image-149"/></figure>
+					<!-- /wp:image --></div></div>
+					<!-- /wp:group -->
+					
+					<!-- wp:button -->
+					<div class="wp-block-button"><a class="wp-block-button__link" href="https://example.com">Click here</a></div>
+					<!-- /wp:button -->',
+			],
+			'multiple_block_lab_blocks_among_others' => [
+				'<!-- wp:block-lab/all-fields-test {"text":"This is some example text","textarea":"Lorem ipsum dolor","url":"https://foobaz.com","email":"art@example.com","number":532,"color":"#2c0c0c","image":149,"select":"baz","multiselect":["foo"],"toggle":true,"range":64,"repeater":{"rows":[{"":"","text":"Here is some text","image":150}]},"post":{"id":606,"name":"Testing"},"rich-text":"\u003cp\u003eThis is \u003cstrong\u003ebold\u003c/strong\u003e and \u003cem\u003eitalic\u003c/em\u003e\u003c/p\u003e","classic-text":"\u003cp\u003eThis is the first line\u003c/p\u003e\n\u003cp\u003e \u003c/p\u003e\n\u003cp\u003eHere is another line\u003c/p\u003e","taxonomy":{"id":5,"name":"Cat"},"user":{"id":1,"userName":"admin"},"checkbox":true,"radio":"another"} /-->
+
+					<!-- wp:archives /-->
+
+					<!-- wp:gallery {"ids":[154,147,148]} -->
+					<figure class="wp-block-gallery columns-3 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://bl.test/wp-content/uploads/2020/01/979-200x400-2.jpg" alt="" data-id="154" data-full-url="https://bl.test/wp-content/uploads/2020/01/979-200x400-2.jpg" data-link="https://bl.test/?attachment_id=154" class="wp-image-154"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://bl.test/wp-content/uploads/2020/01/568-1000x1000-1.jpg" alt="" data-id="147" data-full-url="https://bl.test/wp-content/uploads/2020/01/568-1000x1000-1.jpg" data-link="https://bl.test/?attachment_id=147" class="wp-image-147"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://bl.test/wp-content/uploads/2020/01/726-300x300-1.jpg" alt="" data-id="148" data-full-url="https://bl.test/wp-content/uploads/2020/01/726-300x300-1.jpg" data-link="https://bl.test/?attachment_id=148" class="wp-image-148"/></figure></li></ul></figure>
+					<!-- /wp:gallery -->
+
+					<!-- wp:block-lab/test-post-2 {"post":{"id":606,"name":"Testing"}} /-->
+
+					<!-- wp:block-lab/test-url {"url":"https://example.com/foo"} /-->',
+				'<!-- wp:genesis-custom-blocks/all-fields-test {"text":"This is some example text","textarea":"Lorem ipsum dolor","url":"https://foobaz.com","email":"art@example.com","number":532,"color":"#2c0c0c","image":149,"select":"baz","multiselect":["foo"],"toggle":true,"range":64,"repeater":{"rows":[{"":"","text":"Here is some text","image":150}]},"post":{"id":606,"name":"Testing"},"rich-text":"\u003cp\u003eThis is \u003cstrong\u003ebold\u003c/strong\u003e and \u003cem\u003eitalic\u003c/em\u003e\u003c/p\u003e","classic-text":"\u003cp\u003eThis is the first line\u003c/p\u003e\n\u003cp\u003e \u003c/p\u003e\n\u003cp\u003eHere is another line\u003c/p\u003e","taxonomy":{"id":5,"name":"Cat"},"user":{"id":1,"userName":"admin"},"checkbox":true,"radio":"another"} /-->
+
+					<!-- wp:archives /-->
+
+					<!-- wp:gallery {"ids":[154,147,148]} -->
+					<figure class="wp-block-gallery columns-3 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://bl.test/wp-content/uploads/2020/01/979-200x400-2.jpg" alt="" data-id="154" data-full-url="https://bl.test/wp-content/uploads/2020/01/979-200x400-2.jpg" data-link="https://bl.test/?attachment_id=154" class="wp-image-154"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://bl.test/wp-content/uploads/2020/01/568-1000x1000-1.jpg" alt="" data-id="147" data-full-url="https://bl.test/wp-content/uploads/2020/01/568-1000x1000-1.jpg" data-link="https://bl.test/?attachment_id=147" class="wp-image-147"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://bl.test/wp-content/uploads/2020/01/726-300x300-1.jpg" alt="" data-id="148" data-full-url="https://bl.test/wp-content/uploads/2020/01/726-300x300-1.jpg" data-link="https://bl.test/?attachment_id=148" class="wp-image-148"/></figure></li></ul></figure>
+					<!-- /wp:gallery -->
+
+					<!-- wp:genesis-custom-blocks/test-post-2 {"post":{"id":606,"name":"Testing"}} /-->
+
+					<!-- wp:genesis-custom-blocks/test-url {"url":"https://example.com/foo"} /-->',
 			],
 		];
 	}
@@ -122,12 +185,16 @@ class Test_Post_Content extends WP_UnitTestCase {
 	 * @param string $expected_post_content Expected post_content of the new post.
 	 */
 	public function test_migrate_single( $initial_post_content, $expected_post_content = null ) {
+		// Prevent sanitization of post_content.
+		remove_filter( 'content_save_pre', 'wp_filter_post_kses' );
+
 		if ( null === $expected_post_content ) {
 			$expected_post_content = $initial_post_content;
 		}
 
-		$post = $this->create_block_post( $initial_post_content );
-		$this->assertInternalType( 'int', $this->instance->migrate_single( $post ) );
+		$post         = $this->create_block_post( $initial_post_content );
+		$return_value = $this->instance->migrate_single( $post );
+		$this->assertInternalType( 'int', $return_value );
 
 		$new_post = get_post( $post->ID );
 		$this->assertEquals( $expected_post_content, $new_post->post_content );

--- a/tests/php/unit/blocks/migration/test-class-post-content.php
+++ b/tests/php/unit/blocks/migration/test-class-post-content.php
@@ -226,6 +226,7 @@ class Test_Post_Content extends WP_UnitTestCase {
 	 * Test migrate_all.
 	 *
 	 * @covers \Block_Lab\Blocks\Migration\Post_Content::migrate_all()
+	 * @covers \Block_Lab\Blocks\Migration\Post_Content::query_for_posts()
 	 */
 	public function test_migrate_all() {
 		$post_id = $this->create_block_post( $this->image_block_initial_content );

--- a/tests/php/unit/blocks/migration/test-class-post-content.php
+++ b/tests/php/unit/blocks/migration/test-class-post-content.php
@@ -265,8 +265,7 @@ class Test_Post_Content extends WP_UnitTestCase {
 		$this->assertEquals( $number_of_posts, $queried_posts->post_count );
 
 		// All of the posts should have their 'block-lab' blocks migrated to 'genesis-custom-blocks' namespaces.
-		foreach ( $queried_posts->posts as $post ) {
-			$this->assertEquals( $this->two_blocks_expected_content, $post->post_content );
-		}
+		$actual_post_content = wp_list_pluck( $queried_posts->posts, 'post_content' );
+		$this->assertEmpty( array_diff( $actual_post_content, [ $this->two_blocks_expected_content ] ) );
 	}
 }

--- a/tests/php/unit/blocks/migration/test-class-post-content.php
+++ b/tests/php/unit/blocks/migration/test-class-post-content.php
@@ -229,11 +229,12 @@ class Test_Post_Content extends WP_UnitTestCase {
 	 * @covers \Block_Lab\Blocks\Migration\Post_Content::query_for_posts()
 	 */
 	public function test_migrate_all() {
-		$post_id = $this->create_block_post( $this->image_block_initial_content );
-		$this->instance->migrate_all();
+		$post_id       = $this->create_block_post( $this->image_block_initial_content );
+		$results       = $this->instance->migrate_all();
 		$migrated_post = get_post( $post_id );
 
 		$this->assertEquals( $this->image_block_expected_content, $migrated_post->post_content );
+		$this->assertCount( 1, $results );
 	}
 
 	/**
@@ -244,11 +245,12 @@ class Test_Post_Content extends WP_UnitTestCase {
 	public function test_migrate_all_non_block_lab_blocks_not_affected() {
 		remove_filter( 'content_save_pre', 'wp_filter_post_kses' );
 
-		$post_id = $this->create_block_post( $this->unrelated_blocks );
-		$this->instance->migrate_all();
+		$post_id       = $this->create_block_post( $this->unrelated_blocks );
+		$results       = $this->instance->migrate_all();
 		$migrated_post = get_post( $post_id );
 
 		$this->assertEquals( $this->unrelated_blocks, $migrated_post->post_content );
+		$this->assertEmpty( $results );
 	}
 
 	/**
@@ -264,11 +266,12 @@ class Test_Post_Content extends WP_UnitTestCase {
 			$this->create_block_post( $this->two_blocks_initial_content );
 		}
 
-		$this->instance->migrate_all();
+		$results       = $this->instance->migrate_all();
 		$queried_posts = new WP_Query( [ 'posts_per_page' => -1 ] );
 
 		// There should still be the same number of posts.
 		$this->assertEquals( $number_of_posts, $queried_posts->post_count );
+		$this->assertCount( $number_of_posts, $results );
 
 		// All of the posts should have their 'block-lab' blocks migrated to 'genesis-custom-blocks' namespaces.
 		$actual_post_content = wp_list_pluck( $queried_posts->posts, 'post_content' );

--- a/tests/php/unit/blocks/migration/test-class-post-type.php
+++ b/tests/php/unit/blocks/migration/test-class-post-type.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Test_Migrate_Custom_Post_Type
+ * Test_Post_Type
  *
  * @package Block_Lab
  */
@@ -8,7 +8,7 @@
 use Block_Lab\Blocks\Migration\Post_Type;
 
 /**
- * Class Test_Migrate_Custom_Post_Type
+ * Class Test_Post_Type
  *
  * @package Block_Lab
  */

--- a/tests/php/unit/blocks/migration/test-class-post-type.php
+++ b/tests/php/unit/blocks/migration/test-class-post-type.php
@@ -122,6 +122,7 @@ class Test_Post_Type extends WP_UnitTestCase {
 	 * Test migrate_all.
 	 *
 	 * @covers \Block_Lab\Blocks\Migration\Post_Type::migrate_all()
+	 * @covers \Block_Lab\Blocks\Migration\Post_Type::query_for_posts()
 	 */
 	public function test_migrate_all() {
 		$initial_block_content = [


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Adds PHP functions to migrate the entire site's `post_content` from the `block-lab/` block namespace to `genesis-custom-blocks/`
* There are more considerations after this PR, like a REST API or AJAX endpoint that the UI can use

#### Testing instructions
1. `wp db export # if you'd like, so you can restore to this backup of your DB `
2. `wp eval-file tests/bin/migrate-post-content.php`

<img width="546" alt="wp-cli-file" src="https://user-images.githubusercontent.com/4063887/84827506-2ff4c580-afea-11ea-9081-f282c205f8cf.png">

3. Expected: The WP-CLI command results in 'Success', like above
4. Go to the 'Revision' links shown above
5. Expected: The revision diff only involves `block-lab`. Nothing else should have changed:
<img width="1020" alt="exampled-diff-here" src="https://user-images.githubusercontent.com/4063887/84827765-8feb6c00-afea-11ea-893c-c7671c91d9f5.png">

6. Expected: If there's no `block-lab/` namespace in the content, the post should not be shown in the WP-CLI command output above, and there should of course be no revision.
7. It'd be great if you could go to 40-50 of those revision URLs to sanity-check them, assuming there are that many. It's tedious, but they're all just one revision ID higher than the next. 

8. To reverse this migration:
```sh
wp shell
( new Block_Lab\Blocks\Migration\Post_Content( 'genesis-custom-blocks', 'block-lab' ) )->migrate_all();
```