### PR TITLE
Migrate the `block_lab` icon to the new name

### DIFF
--- a/php/blocks/migration/class-post-type.php
+++ b/php/blocks/migration/class-post-type.php
@@ -101,7 +101,13 @@ class Post_Type {
 			return false;
 		}
 
-		$block_contents = $block[ $old_block_name ];
+		$block_contents        = $block[ $old_block_name ];
+		$previous_default_icon = 'block_lab';
+		$new_default_icon      = 'genesis_custom_blocks';
+		if ( isset( $block_contents['icon'] ) && $previous_default_icon === $block_contents['icon'] ) {
+			$block_contents['icon'] = $new_default_icon;
+		}
+
 		$new_block_name = preg_replace( '#^' . $this->previous_block_namespace . '(?=/)#', $this->new_block_namespace, $old_block_name );
 		$new_block      = [ $new_block_name => $block_contents ];
 

--- a/tests/php/unit/blocks/migration/test-class-post-type.php
+++ b/tests/php/unit/blocks/migration/test-class-post-type.php
@@ -63,7 +63,7 @@ class Test_Post_Type extends WP_UnitTestCase {
 	 *
 	 * @var string
 	 */
-	public $simple_block_expected_content = '{"placeholder\/test-image":{"name":"test-image","title":"Test Image","excluded":[],"icon":"block_lab","category":{"slug":"common","title":"Common Blocks","icon":null},"keywords":[""],"fields":{"image":{"name":"image","label":"Image","control":"image","type":"integer","order":0,"location":"editor","width":"50","help":"Here is some help text"}}}}';
+	public $simple_block_expected_content = '{"placeholder\/test-image":{"name":"test-image","title":"Test Image","excluded":[],"icon":"genesis_custom_blocks","category":{"slug":"common","title":"Common Blocks","icon":null},"keywords":[""],"fields":{"image":{"name":"image","label":"Image","control":"image","type":"integer","order":0,"location":"editor","width":"50","help":"Here is some help text"}}}}';
 
 	/**
 	 * Initial content for a repeater block.
@@ -77,7 +77,7 @@ class Test_Post_Type extends WP_UnitTestCase {
 	 *
 	 * @var string
 	 */
-	public $repeater_block_expected_content = '{"placeholder\/test-repeater":{"name":"test-repeater","title":"Test Repeater","excluded":[],"icon":"block_lab","category":{"slug":"layout","title":"Layout Elements","icon":null},"keywords":["repeater","panel","example"],"fields":{"repeater":{"name":"repeater","label":"Repeater","control":"repeater","type":"object","order":0,"help":"","min":1,"max":4,"sub_fields":{"textarea":{"name":"textarea","label":"Textarea","control":"textarea","type":"textarea","order":0,"location":null,"width":"","help":"This is more help text","default":"This is an example default value","placeholder":"Here is some placeholder text","maxlength":4,"number_rows":4,"new_lines":"autop","parent":"repeater"},"color":{"name":"color","label":"This is a label","control":"color","type":"string","order":1,"location":null,"width":"","help":"Here is some help text","default":"#ffffff","parent":"repeater"},"select":{"name":"select","label":"Select","control":"select","type":"string","order":2,"location":null,"width":"","help":"Here is some help text","options":[{"label":"First","value":"first"},{"label":"Second","value":"second"},{"label":"Third","value":"third"}],"default":"second","parent":"repeater"}}},"number":{"name":"number","label":"Number","control":"number","type":"integer","order":1,"location":"editor","width":"100","help":"This is example help text","default":"52","placeholder":"Enter a number"}}}}';
+	public $repeater_block_expected_content = '{"placeholder\/test-repeater":{"name":"test-repeater","title":"Test Repeater","excluded":[],"icon":"genesis_custom_blocks","category":{"slug":"layout","title":"Layout Elements","icon":null},"keywords":["repeater","panel","example"],"fields":{"repeater":{"name":"repeater","label":"Repeater","control":"repeater","type":"object","order":0,"help":"","min":1,"max":4,"sub_fields":{"textarea":{"name":"textarea","label":"Textarea","control":"textarea","type":"textarea","order":0,"location":null,"width":"","help":"This is more help text","default":"This is an example default value","placeholder":"Here is some placeholder text","maxlength":4,"number_rows":4,"new_lines":"autop","parent":"repeater"},"color":{"name":"color","label":"This is a label","control":"color","type":"string","order":1,"location":null,"width":"","help":"Here is some help text","default":"#ffffff","parent":"repeater"},"select":{"name":"select","label":"Select","control":"select","type":"string","order":2,"location":null,"width":"","help":"Here is some help text","options":[{"label":"First","value":"first"},{"label":"Second","value":"second"},{"label":"Third","value":"third"}],"default":"second","parent":"repeater"}}},"number":{"name":"number","label":"Number","control":"number","type":"integer","order":1,"location":"editor","width":"100","help":"This is example help text","default":"52","placeholder":"Enter a number"}}}}';
 
 	/**
 	 * Initial content for a post block.
@@ -91,7 +91,21 @@ class Test_Post_Type extends WP_UnitTestCase {
 	 *
 	 * @var string
 	 */
-	public $post_block_expected_content = '{"placeholder\/test-post-2":{"name":"test-post-2","title":"Test Post","excluded":[],"icon":"block_lab","category":{"slug":"common","title":"Common Blocks","icon":null},"keywords":[""],"fields":{"post":{"name":"post","label":"Post","control":"post","type":"object","order":0,"location":"editor","width":"75","help":"This is a post","post_type_rest_slug":"posts"}}}}';
+	public $post_block_expected_content = '{"placeholder\/test-post-2":{"name":"test-post-2","title":"Test Post","excluded":[],"icon":"genesis_custom_blocks","category":{"slug":"common","title":"Common Blocks","icon":null},"keywords":[""],"fields":{"post":{"name":"post","label":"Post","control":"post","type":"object","order":0,"location":"editor","width":"75","help":"This is a post","post_type_rest_slug":"posts"}}}}';
+
+	/**
+	 * Initial content for a block with a non-default icon.
+	 *
+	 * @var string
+	 */
+	public $different_icon_block_initial_content = '{"block-lab\/test-post-2":{"name":"test-post-2","title":"Test Post","excluded":[],"icon":"bookmark_border","category":{"slug":"common","title":"Common Blocks","icon":null},"keywords":[""],"fields":{"post":{"name":"post","label":"Post","control":"post","type":"object","order":0,"location":"editor","width":"75","help":"This is a post","post_type_rest_slug":"posts"}}}}';
+
+	/**
+	 * Expected content for a block with a non-default icon.
+	 *
+	 * @var string
+	 */
+	public $different_icon_block_expected_content = '{"placeholder\/test-post-2":{"name":"test-post-2","title":"Test Post","excluded":[],"icon":"bookmark_border","category":{"slug":"common","title":"Common Blocks","icon":null},"keywords":[""],"fields":{"post":{"name":"post","label":"Post","control":"post","type":"object","order":0,"location":"editor","width":"75","help":"This is a post","post_type_rest_slug":"posts"}}}}';
 
 	/**
 	 * Sets up each test.
@@ -281,6 +295,11 @@ class Test_Post_Type extends WP_UnitTestCase {
 			'post_block'                      => [
 				$this->post_block_initial_content,
 				$this->post_block_expected_content,
+				self::NEW_POST_TYPE_SLUG,
+			],
+			'non_default_icon'                => [
+				$this->different_icon_block_initial_content,
+				$this->different_icon_block_expected_content,
 				self::NEW_POST_TYPE_SLUG,
 			],
 		];


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* If a block's icon is `block_lab`, migrate it to the new name
* Otherwise, this does nothing to the icon.
#### Testing instructions
* Run PHPUnit tests
* No way to functionally test this yet, as it's not connected to a GUI
