### PR TITLE
Add a migration notice on certain pages

### DIFF
--- a/css/admin.migration-notice.css
+++ b/css/admin.migration-notice.css
@@ -17,3 +17,7 @@
 .bl-notice-migration.bl-hidden {
 	display: none;
 }
+
+#bl-notice-not-now {
+	margin-left: 16px;
+}

--- a/css/admin.migration-notice.css
+++ b/css/admin.migration-notice.css
@@ -1,7 +1,5 @@
 .bl-notice-migration {
 	display: flex;
-	flex-flow: row;
-	justify-content: flex-start;
 }
 
 .bl-notice-migration .bl-migration-copy {

--- a/css/admin.migration-notice.css
+++ b/css/admin.migration-notice.css
@@ -1,17 +1,21 @@
-.bl-migration-notice {
+.bl-notice-migration {
 	display: flex;
 	flex-flow: row;
 	justify-content: flex-start;
 }
 
-.bl-migration-notice .bl-migration-copy {
+.bl-notice-migration .bl-migration-copy {
 	margin-right: auto;
 }
 
-.bl-migration-notice .bl-notice-option {
+.bl-notice-migration .bl-notice-option {
 	text-decoration: none;
 	width: 5rem;
 	display: flex;
 	justify-content: center;
 	align-items: center;
+}
+
+.bl-notice-migration.bl-hidden {
+	display: none;
 }

--- a/css/admin.migration-notice.css
+++ b/css/admin.migration-notice.css
@@ -1,0 +1,17 @@
+.bl-migration-notice {
+	display: flex;
+	flex-flow: row;
+	justify-content: flex-start;
+}
+
+.bl-migration-notice .bl-migration-copy {
+	margin-right: auto;
+}
+
+.bl-migration-notice .bl-notice-option {
+	text-decoration: none;
+	width: 5rem;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}

--- a/css/admin.migration-notice.css
+++ b/css/admin.migration-notice.css
@@ -6,12 +6,12 @@
 	margin-right: auto;
 }
 
+.bl-notice-migration__learn-more {
+	display: block;
+}
+
 .bl-notice-migration .bl-notice-option {
-	text-decoration: none;
-	width: 5rem;
-	display: flex;
-	justify-content: center;
-	align-items: center;
+	margin: auto 0.2rem;
 }
 
 .bl-notice-migration.bl-hidden {

--- a/js/admin.migration-notice.js
+++ b/js/admin.migration-notice.js
@@ -3,7 +3,8 @@
 document.addEventListener( 'DOMContentLoaded', function() {
 	const hiddenClass = 'bl-hidden';
 
-	// On clicking 'Not now', make an AJAX request to store the user meta to not display the notice again.
+	// In the main migration notice, On clicking 'Not Now',
+	// make an AJAX request to store the user meta to not display the notice again.
 	// Also, remove this notice and display another.
 	document.querySelector( '#bl-notice-not-now' ).addEventListener( 'click', function() {
 		const request = new XMLHttpRequest();
@@ -16,6 +17,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 		const notice = document.querySelector( '#bl-migration-notice' );
 		notice.parentNode.removeChild( notice );
+
+		// Display the 'Not Now' notice.
 		document.querySelector( '#bl-not-now-notice' ).classList.remove( hiddenClass );
 	} );
 

--- a/js/admin.migration-notice.js
+++ b/js/admin.migration-notice.js
@@ -3,7 +3,7 @@
 document.addEventListener( 'DOMContentLoaded', function() {
 	const hiddenClass = 'bl-hidden';
 
-	// In the main migration notice, On clicking 'Not Now',
+	// In the main migration notice, on clicking 'Not Now',
 	// make an AJAX request to store the user meta to not display the notice again.
 	// Also, remove this notice and display another.
 	document.querySelector( '#bl-notice-not-now' ).addEventListener( 'click', function() {
@@ -15,6 +15,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		request.open( 'POST', ajaxurl, true );
 		request.send( data );
 
+		// Remove this notice.
 		const notice = document.querySelector( '#bl-migration-notice' );
 		notice.parentNode.removeChild( notice );
 

--- a/js/admin.migration-notice.js
+++ b/js/admin.migration-notice.js
@@ -1,0 +1,26 @@
+/* global XMLHttpRequest, FormData, ajaxurl */
+
+document.addEventListener( 'DOMContentLoaded', function() {
+	const hiddenClass = 'bl-hidden';
+
+	// On clicking 'Not now', make an AJAX request to store the user meta to not display the notice again.
+	// Also, remove this notice and display another.
+	document.querySelector( '#bl-notice-not-now' ).addEventListener( 'click', function() {
+		const request = new XMLHttpRequest();
+		const data = new FormData();
+		data.append( 'action', 'bl_dismiss_migration_notice' );
+		data.append( 'bl-migration-nonce-name', document.querySelector( '#bl-migration-nonce-name' ).value );
+
+		request.open( 'POST', ajaxurl, true );
+		request.send( data );
+
+		const notice = document.querySelector( '#bl-migration-notice' );
+		notice.parentNode.removeChild( notice );
+		document.querySelector( '#bl-not-now-notice' ).classList.remove( hiddenClass );
+	} );
+
+	// In the 'Not Now' notice, on clicking 'OK', hide the notice.
+	document.querySelector( '#bl-notice-ok' ).addEventListener( 'click', function() {
+		document.querySelector( '#bl-not-now-notice' ).classList.add( hiddenClass );
+	} );
+} );

--- a/php/admin/class-admin.php
+++ b/php/admin/class-admin.php
@@ -38,6 +38,13 @@ class Admin extends Component_Abstract {
 	public $onboarding;
 
 	/**
+	 * Migration to the new plugin.
+	 *
+	 * @var Migration
+	 */
+	public $migration;
+
+	/**
 	 * Plugin upgrade.
 	 *
 	 * @var Upgrade
@@ -63,6 +70,9 @@ class Admin extends Component_Abstract {
 
 		$this->onboarding = new Onboarding();
 		block_lab()->register_component( $this->onboarding );
+
+		$this->migration = new Migration();
+		block_lab()->register_component( $this->migration );
 
 		$show_pro_nag = apply_filters( 'block_lab_show_pro_nag', false );
 		if ( $show_pro_nag && ! block_lab()->is_pro() ) {

--- a/php/admin/class-migration.php
+++ b/php/admin/class-migration.php
@@ -106,7 +106,10 @@ class Migration extends Component_Abstract {
 					printf(
 						/* translators: %1$s: the plugin name */
 						esc_html__( 'The Block Lab team have moved. For future updates and improvements, migrate now to the new home of custom blocks: %1$s.', 'block-lab' ),
-						'<strong>Genesis Custom Blocks</strong>'
+						sprintf(
+							 '<strong>%1$s</strong>',
+							esc_html__( 'Genesis Custom Blocks', 'block-lab' )
+						)
 					);
 					?>
 				</p>
@@ -197,7 +200,7 @@ class Migration extends Component_Abstract {
 		check_ajax_referer( self::NOTICE_NONCE_ACTION, self::NOTICE_NONCE_NAME );
 
 		if ( ! current_user_can( self::NOTICE_CAPABILITY ) ) {
-			wp_die( -1 );
+			wp_send_json_error();
 		}
 
 		update_user_meta( get_current_user_id(), self::NOTICE_USER_META_KEY, self::NOTICE_DISMISSED_META_VALUE );

--- a/php/admin/class-migration.php
+++ b/php/admin/class-migration.php
@@ -17,33 +17,61 @@ use Block_Lab\Component_Abstract;
 class Migration extends Component_Abstract {
 
 	/**
+	 * The action of the migration notice nonce.
+	 *
+	 * @var string
+	 */
+	const NOTICE_NONCE_ACTION = 'bl-migration-nonce';
+
+	/**
+	 * The name of the migration notice nonce.
+	 *
+	 * @var string
+	 */
+	const NOTICE_NONCE_NAME = 'bl-migration-nonce-name';
+
+	/**
+	 * The slug of the stylesheet for the migration notice.
+	 *
+	 * @var string
+	 */
+	const NOTICE_STYLE_SLUG = 'block-lab-migration-notice-style';
+
+	/**
+	 * The slug of the stylesheet for the migration notice.
+	 *
+	 * @var string
+	 */
+	const NOTICE_SCRIPT_SLUG = 'block-lab-migration-notice-script';
+
+	/**
 	 * Adds an action for the notice.
 	 */
 	public function register_hooks() {
-		add_action( 'admin_notices', [ $this, 'migration_notice' ] );
+		add_action( 'admin_notices', [ $this, 'render_migration_notice' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 	}
 
 	/**
 	 * Outputs the migration notice if this is on the right page and the user has the right permission.
-	 *
-	 * This should display on Block Lab > Content Blocks,
-	 * /wp-admin/plugins.php, the Dashboard, and Block Lab > Settings.
 	 */
-	public function migration_notice() {
-		if ( ! current_user_can( 'install_plugins' ) ) {
+	public function render_migration_notice() {
+		if ( ! $this->should_display_migration_notice() ) {
 			return;
 		}
 
-		$screen         = get_current_screen();
-		$should_display = (
-			( isset( $screen->base, $screen->post_type ) && 'edit' === $screen->base && 'block_lab' === $screen->post_type )
-			||
-			( isset( $screen->base ) && in_array( $screen->base, [ 'plugins', 'dashboard', 'block_lab_page_block-lab-settings' ], true ) )
+		$migration_url = add_query_arg(
+			[
+				'post_type' => block_lab()->get_slug(),
+				'page'      => 'block-lab-migration',
+			],
+			admin_url( 'edit.php' )
 		);
 
-		if ( $should_display ) {
-			?>
-			<div class="notice updated is-dismissible">
+		?>
+		<div class="bl-migration-notice notice notice-info">
+			<?php wp_nonce_field( self::NOTICE_NONCE_ACTION, self::NOTICE_NONCE_NAME, false ); ?>
+			<div class="bl-migration-copy">
 				<p>
 					<?php
 					printf(
@@ -62,7 +90,58 @@ class Migration extends Component_Abstract {
 					?>
 				</p>
 			</div>
-			<?php
+			<a href="#" class="bl-notice-option">
+				<?php esc_html_e( 'Not now', 'block-lab' ); ?>
+			</a>
+			<a href="<?php echo esc_url( $migration_url ); ?>" class="bl-notice-option">
+				<?php esc_html_e( 'Migrate', 'block-lab' ); ?>
+			</a>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Enqueues the migration notice assets.
+	 */
+	public function enqueue_assets() {
+		if ( ! $this->should_display_migration_notice() ) {
+			return;
 		}
+
+		wp_enqueue_style(
+			self::NOTICE_STYLE_SLUG,
+			$this->plugin->get_url( 'css/admin.migration-notice.css' ),
+			[],
+			$this->plugin->get_version()
+		);
+
+		wp_enqueue_script(
+			self::NOTICE_SCRIPT_SLUG,
+			$this->plugin->get_url( 'js/admin.migration-notice.js' ),
+			[],
+			$this->plugin->get_version(),
+			true
+		);
+	}
+
+	/**
+	 * Gets whether the migration notice should display.
+	 *
+	 * This should display on Block Lab > Content Blocks,
+	 * /wp-admin/plugins.php, the Dashboard, and Block Lab > Settings.
+	 *
+	 * @return bool Whether the migration notice should display.
+	 */
+	public function should_display_migration_notice() {
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return false;
+		}
+
+		$screen = get_current_screen();
+		return (
+			( isset( $screen->base, $screen->post_type ) && 'edit' === $screen->base && 'block_lab' === $screen->post_type )
+			||
+			( isset( $screen->base ) && in_array( $screen->base, [ 'plugins', 'dashboard', 'block_lab_page_block-lab-settings' ], true ) )
+		);
 	}
 }

--- a/php/admin/class-migration.php
+++ b/php/admin/class-migration.php
@@ -43,14 +43,14 @@ class Migration extends Component_Abstract {
 	const NOTICE_STYLE_SLUG = 'block-lab-migration-notice-style';
 
 	/**
-	 * The slug of the stylesheet for the migration notice.
+	 * The slug of the script for the migration notice.
 	 *
 	 * @var string
 	 */
 	const NOTICE_SCRIPT_SLUG = 'block-lab-migration-notice-script';
 
 	/**
-	 * The user meta key to store if a user has dismissed the migration notice.
+	 * The user meta key to store whether a user has dismissed the migration notice.
 	 *
 	 * @var string
 	 */
@@ -61,7 +61,14 @@ class Migration extends Component_Abstract {
 	 *
 	 * @var string
 	 */
-	const NOTICE_DISMISSED_META_VALUE = '0';
+	const NOTICE_DISMISSED_META_VALUE = 'dismissed';
+
+	/**
+	 * The capability required to see the notice.
+	 *
+	 * @var string
+	 */
+	const NOTICE_CAPABILITY = 'install_plugins';
 
 	/**
 	 * Adds an action for the notice.
@@ -161,7 +168,7 @@ class Migration extends Component_Abstract {
 	 * @return bool Whether the migration notice should display.
 	 */
 	public function should_display_migration_notice() {
-		if ( ! current_user_can( 'install_plugins' ) ) {
+		if ( ! current_user_can( self::NOTICE_CAPABILITY ) ) {
 			return false;
 		}
 
@@ -180,11 +187,14 @@ class Migration extends Component_Abstract {
 
 	/**
 	 * Handles an AJAX request to not display the notice.
+	 *
+	 * This stores in the user meta the fact that the notice was dismissed,
+	 * so it's not displayed again.
 	 */
 	public function ajax_handler_migration_notice() {
 		check_ajax_referer( self::NOTICE_NONCE_ACTION, self::NOTICE_NONCE_NAME );
 
-		if ( ! current_user_can( 'edit_theme_options' ) ) {
+		if ( ! current_user_can( self::NOTICE_CAPABILITY ) ) {
 			wp_die( -1 );
 		}
 

--- a/php/admin/class-migration.php
+++ b/php/admin/class-migration.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Enable and validate Pro version licensing.
+ * Handles migration to the new plugin.
  *
  * @package   Block_Lab
  * @copyright Copyright(c) 2020, Block Lab
@@ -111,7 +111,7 @@ class Migration extends Component_Abstract {
 				</p>
 			</div>
 			<a href="#" id="bl-notice-not-now" class="bl-notice-option">
-				<?php esc_html_e( 'Not now', 'block-lab' ); ?>
+				<?php esc_html_e( 'Not Now', 'block-lab' ); ?>
 			</a>
 			<a href="<?php echo esc_url( $migration_url ); ?>" class="bl-notice-option">
 				<?php esc_html_e( 'Migrate', 'block-lab' ); ?>
@@ -122,7 +122,7 @@ class Migration extends Component_Abstract {
 				<p><?php esc_html_e( "When you're ready, our migration tool is available in the main menu, under Block Lab > Migrate.", 'block-lab' ); ?></p>
 			</div>
 			<a href="#" id="bl-notice-ok" class="bl-notice-option">
-				<?php esc_html_e( 'OK', 'block-lab' ); ?>
+				<?php esc_html_e( 'Okay', 'block-lab' ); ?>
 			</a>
 		</div>
 		<?php

--- a/php/admin/class-migration.php
+++ b/php/admin/class-migration.php
@@ -107,7 +107,7 @@ class Migration extends Component_Abstract {
 						/* translators: %1$s: the plugin name */
 						esc_html__( 'The Block Lab team have moved. For future updates and improvements, migrate now to the new home of custom blocks: %1$s.', 'block-lab' ),
 						sprintf(
-							 '<strong>%1$s</strong>',
+							'<strong>%1$s</strong>',
 							esc_html__( 'Genesis Custom Blocks', 'block-lab' )
 						)
 					);
@@ -205,6 +205,6 @@ class Migration extends Component_Abstract {
 
 		update_user_meta( get_current_user_id(), self::NOTICE_USER_META_KEY, self::NOTICE_DISMISSED_META_VALUE );
 
-		wp_die( 1 );
+		wp_send_json_success();
 	}
 }

--- a/php/admin/class-migration.php
+++ b/php/admin/class-migration.php
@@ -24,12 +24,16 @@ class Migration extends Component_Abstract {
 	}
 
 	/**
-	 * Outputs the migration notice if this is on the right page.
+	 * Outputs the migration notice if this is on the right page and the user has the right permission.
 	 *
 	 * This should display on Block Lab > Content Blocks,
 	 * /wp-admin/plugins.php, the Dashboard, and Block Lab > Settings.
 	 */
 	public function migration_notice() {
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return;
+		}
+
 		$screen         = get_current_screen();
 		$should_display = (
 			( isset( $screen->base, $screen->post_type ) && 'edit' === $screen->base && 'block_lab' === $screen->post_type )
@@ -38,10 +42,27 @@ class Migration extends Component_Abstract {
 		);
 
 		if ( $should_display ) {
-			printf(
-				'<div class="notice updated is-dismissible"><p>%1$s</p></div>',
-				esc_html__( 'The Block Lab team have moved. For future updates and improvements, migrate now to the new home of custom blocks: Genesis Custom Blocks.', 'block-lab' )
-			);
+			?>
+			<div class="notice updated is-dismissible">
+				<p>
+					<?php
+					printf(
+						/* translators: %1$s: the plugin name */
+						esc_html__( 'The Block Lab team have moved. For future updates and improvements, migrate now to the new home of custom blocks: %1$s', 'block-lab' ),
+						'<strong>Genesis Custom Blocks.</strong>'
+					);
+					?>
+				</p>
+				<p>
+					<?php
+					printf(
+						'<a target="_blank" href="https://getblocklab.com/docs/genesis-custom-blocks">%1$s</a>',
+						esc_html__( 'Learn more', 'block-lab' )
+					);
+					?>
+				</p>
+			</div>
+			<?php
 		}
 	}
 }

--- a/php/admin/class-migration.php
+++ b/php/admin/class-migration.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Enable and validate Pro version licensing.
+ *
+ * @package   Block_Lab
+ * @copyright Copyright(c) 2020, Block Lab
+ * @license   http://opensource.org/licenses/GPL-2.0 GNU General Public License, version 2 (GPL-2.0)
+ */
+
+namespace Block_Lab\Admin;
+
+use Block_Lab\Component_Abstract;
+
+/**
+ * Class Migration
+ */
+class Migration extends Component_Abstract {
+
+	/**
+	 * Adds an action for the notice.
+	 */
+	public function register_hooks() {
+		add_action( 'admin_notices', [ $this, 'migration_notice' ] );
+	}
+
+	/**
+	 * Outputs the migration notice if this is on the right page.
+	 *
+	 * This should display on Block Lab > Content Blocks,
+	 * /wp-admin/plugins.php, the Dashboard, and Block Lab > Settings.
+	 */
+	public function migration_notice() {
+		$screen         = get_current_screen();
+		$should_display = (
+			( isset( $screen->base, $screen->post_type ) && 'edit' === $screen->base && 'block_lab' === $screen->post_type )
+			||
+			( isset( $screen->base ) && in_array( $screen->base, [ 'plugins', 'dashboard', 'block_lab_page_block-lab-settings' ], true ) )
+		);
+
+		if ( $should_display ) {
+			printf(
+				'<div class="notice updated is-dismissible"><p>%1$s</p></div>',
+				esc_html__( 'The Block Lab team have moved. For future updates and improvements, migrate now to the new home of custom blocks: Genesis Custom Blocks.', 'block-lab' )
+			);
+		}
+	}
+}

--- a/php/admin/class-migration.php
+++ b/php/admin/class-migration.php
@@ -18,6 +18,8 @@ class Migration extends Component_Abstract {
 
 	/**
 	 * The AJAX action to dismiss the migration notice.
+	 *
+	 * @var string
 	 */
 	const NOTICE_AJAX_ACTION = 'bl_dismiss_migration_notice';
 
@@ -103,8 +105,8 @@ class Migration extends Component_Abstract {
 					<?php
 					printf(
 						/* translators: %1$s: the plugin name */
-						esc_html__( 'The Block Lab team have moved. For future updates and improvements, migrate now to the new home of custom blocks: %1$s', 'block-lab' ),
-						'<strong>Genesis Custom Blocks.</strong>'
+						esc_html__( 'The Block Lab team have moved. For future updates and improvements, migrate now to the new home of custom blocks: %1$s.', 'block-lab' ),
+						'<strong>Genesis Custom Blocks</strong>'
 					);
 					?>
 				</p>

--- a/php/admin/class-migration.php
+++ b/php/admin/class-migration.php
@@ -89,7 +89,9 @@ class Migration extends Component_Abstract {
 			return;
 		}
 
-		$migration_url = add_query_arg(
+		// @todo: verify that this doc page exists, or change it to one that does exist.
+		$learn_more_link = 'https://getblocklab.com/docs/genesis-custom-blocks';
+		$migration_url   = add_query_arg(
 			[
 				'post_type' => block_lab()->get_slug(),
 				'page'      => 'block-lab-migration',
@@ -112,20 +114,15 @@ class Migration extends Component_Abstract {
 						)
 					);
 					?>
-				</p>
-				<p>
-					<?php
-					printf(
-						'<a target="_blank" href="https://getblocklab.com/docs/genesis-custom-blocks">%1$s</a>',
-						esc_html__( 'Learn more', 'block-lab' )
-					);
-					?>
+					<a target="_blank" rel="noopener noreferrer" class="bl-notice-migration__learn-more" href="<?php echo esc_url( $learn_more_link ); ?>">
+						<?php esc_html_e( 'Learn more', 'block-lab' ); ?>
+					</a>
 				</p>
 			</div>
-			<a href="#" id="bl-notice-not-now" class="bl-notice-option">
+			<button id="bl-notice-not-now" href="#" class="bl-notice-option button button-secondary">
 				<?php esc_html_e( 'Not Now', 'block-lab' ); ?>
-			</a>
-			<a href="<?php echo esc_url( $migration_url ); ?>" class="bl-notice-option">
+			</button>
+			<a href="<?php echo esc_url( $migration_url ); ?>" class="bl-notice-option button button-primary">
 				<?php esc_html_e( 'Migrate', 'block-lab' ); ?>
 			</a>
 		</div>

--- a/tests/php/unit/admin/test-class-admin.php
+++ b/tests/php/unit/admin/test-class-admin.php
@@ -58,10 +58,12 @@ class Test_Admin extends \WP_UnitTestCase {
 	public function test_init() {
 		$this->set_license_validity( false );
 		$this->instance->init();
-		$settings_class = 'Block_Lab\Admin\Settings';
-		$license_class  = 'Block_Lab\Admin\License';
+		$settings_class  = 'Block_Lab\Admin\Settings';
+		$license_class   = 'Block_Lab\Admin\License';
+		$migration_class = 'Block_Lab\Admin\Migration';
 		$this->assertEquals( $settings_class, get_class( $this->instance->settings ) );
 		$this->assertEquals( $license_class, get_class( $this->instance->license ) );
+		$this->assertEquals( $migration_class, get_class( $this->instance->migration ) );
 
 		$block_lab_reflection = new ReflectionObject( block_lab() );
 		$components           = $block_lab_reflection->getProperty( 'components' );
@@ -72,6 +74,7 @@ class Test_Admin extends \WP_UnitTestCase {
 		$this->assertEquals( $this->instance->settings->slug, $components_value[ $settings_class ]->slug );
 		$this->assertArrayHasKey( $settings_class, $components_value );
 		$this->assertArrayHasKey( $license_class, $components_value );
+		$this->assertArrayHasKey( $migration_class, $components_value );
 
 		// With an active Pro license, this should redirect from the Pro page to the settings page.
 		$this->set_license_validity( true );

--- a/tests/php/unit/admin/test-class-migration.php
+++ b/tests/php/unit/admin/test-class-migration.php
@@ -106,6 +106,9 @@ class Test_Migration extends \WP_UnitTestCase {
 	 */
 	public function test_ajax_handler_migration_notice() {
 		$this->give_user_permissions();
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', '__return_false' );
+
 		expect( 'check_ajax_referer' )
 			->once()
 			->with(

--- a/tests/php/unit/admin/test-class-migration.php
+++ b/tests/php/unit/admin/test-class-migration.php
@@ -21,7 +21,12 @@ class Test_Migration extends \WP_UnitTestCase {
 	 *
 	 * @var string
 	 */
-	const EXPECTED_MIGRATION_NOTICE = '<div class="notice updated is-dismissible"><p>The Block Lab team have moved. For future updates and improvements, migrate now to the new home of custom blocks: Genesis Custom Blocks.</p></div>';
+	public $expected_migration_notice = '<div class="notice updated is-dismissible">
+		<p>
+			The Block Lab team have moved. For future updates and improvements, migrate now to the new home of custom blocks: <strong>Genesis Custom Blocks.</strong>
+		</p>
+		<p><a target="_blank" href="https://getblocklab.com/docs/genesis-custom-blocks">Learn more</a></p>
+	</div>';
 
 	/**
 	 * Instance of Migration.
@@ -75,11 +80,24 @@ class Test_Migration extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test migration_notice when a user does not have the right permission to see the notice.
+	 *
+	 * @covers \Block_Lab\Admin\Migration::migration_notice()
+	 */
+	public function test_migration_notice_wrong_user() {
+		ob_start();
+		$this->instance->migration_notice();
+
+		$this->assertEmpty( ob_get_clean() );
+	}
+
+	/**
 	 * Test migration_notice on the Block Lab settings page.
 	 *
 	 * @covers \Block_Lab\Admin\Migration::migration_notice()
 	 */
 	public function test_migration_notice_appears_on_settings_page() {
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$mock_current_screen       = new stdClass();
 		$mock_current_screen->base = 'block_lab_page_block-lab-settings';
 
@@ -90,8 +108,8 @@ class Test_Migration extends \WP_UnitTestCase {
 		ob_start();
 		$this->instance->migration_notice();
 
-		$this->assertEquals(
-			self::EXPECTED_MIGRATION_NOTICE,
+		$this->assert_equal_markup(
+			$this->expected_migration_notice,
 			ob_get_clean()
 		);
 	}
@@ -102,6 +120,7 @@ class Test_Migration extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Admin\Migration::migration_notice()
 	 */
 	public function test_migration_notice_appears_on_content_blocks_page() {
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$mock_current_screen            = new stdClass();
 		$mock_current_screen->post_type = 'block_lab';
 		$mock_current_screen->base      = 'edit';
@@ -113,8 +132,8 @@ class Test_Migration extends \WP_UnitTestCase {
 		ob_start();
 		$this->instance->migration_notice();
 
-		$this->assertEquals(
-			self::EXPECTED_MIGRATION_NOTICE,
+		$this->assert_equal_markup(
+			$this->expected_migration_notice,
 			ob_get_clean()
 		);
 	}
@@ -125,6 +144,7 @@ class Test_Migration extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Admin\Migration::migration_notice()
 	 */
 	public function test_migration_notice_appears_on_plugins_page() {
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$mock_current_screen       = new stdClass();
 		$mock_current_screen->base = 'plugins';
 
@@ -135,8 +155,8 @@ class Test_Migration extends \WP_UnitTestCase {
 		ob_start();
 		$this->instance->migration_notice();
 
-		$this->assertEquals(
-			self::EXPECTED_MIGRATION_NOTICE,
+		$this->assert_equal_markup(
+			$this->expected_migration_notice,
 			ob_get_clean()
 		);
 	}
@@ -147,6 +167,7 @@ class Test_Migration extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Admin\Migration::migration_notice()
 	 */
 	public function test_migration_notice_appears_on_dashboard() {
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$mock_current_screen       = new stdClass();
 		$mock_current_screen->base = 'dashboard';
 
@@ -157,8 +178,8 @@ class Test_Migration extends \WP_UnitTestCase {
 		ob_start();
 		$this->instance->migration_notice();
 
-		$this->assertEquals(
-			self::EXPECTED_MIGRATION_NOTICE,
+		$this->assert_equal_markup(
+			$this->expected_migration_notice,
 			ob_get_clean()
 		);
 	}

--- a/tests/php/unit/admin/test-class-migration.php
+++ b/tests/php/unit/admin/test-class-migration.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Tests for class Migration.
+ *
+ * @package Block_Lab
+ */
+
+use Block_Lab\Admin\Migration;
+use Brain\Monkey;
+use function Brain\Monkey\Functions\expect;
+
+/**
+ * Tests for class Migration.
+ */
+class Test_Migration extends \WP_UnitTestCase {
+
+	use Testing_Helper;
+
+	/**
+	 * The migration notice.
+	 *
+	 * @var string
+	 */
+	const EXPECTED_MIGRATION_NOTICE = '<div class="notice updated is-dismissible"><p>The Block Lab team have moved. For future updates and improvements, migrate now to the new home of custom blocks: Genesis Custom Blocks.</p></div>';
+
+	/**
+	 * Instance of Migration.
+	 *
+	 * @var Migration
+	 */
+	public $instance;
+
+	/**
+	 * Set up each test.
+	 *
+	 * @inheritdoc
+	 */
+	public function setUp() {
+		parent::setUp();
+		Monkey\setUp();
+		$this->instance = new Migration();
+		$this->instance->set_plugin( block_lab() );
+	}
+
+	/**
+	 * Tear down after each test.
+	 *
+	 * @inheritdoc
+	 */
+	public function tearDown() {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test register_hooks.
+	 *
+	 * @covers \Block_Lab\Admin\Migration::register_hooks()
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+		$this->assertEquals( 10, has_action( 'admin_notices', [ $this->instance, 'migration_notice' ] ) );
+	}
+
+	/**
+	 * Test migration_notice when on a page where it shouldn't appear.
+	 *
+	 * @covers \Block_Lab\Admin\Migration::migration_notice()
+	 */
+	public function test_migration_notice_wrong_page() {
+		ob_start();
+		$this->instance->migration_notice();
+
+		$this->assertEmpty( ob_get_clean() );
+	}
+
+	/**
+	 * Test migration_notice on the Block Lab settings page.
+	 *
+	 * @covers \Block_Lab\Admin\Migration::migration_notice()
+	 */
+	public function test_migration_notice_appears_on_settings_page() {
+		$mock_current_screen       = new stdClass();
+		$mock_current_screen->base = 'block_lab_page_block-lab-settings';
+
+		expect( 'get_current_screen' )
+			->once()
+			->andReturn( $mock_current_screen );
+
+		ob_start();
+		$this->instance->migration_notice();
+
+		$this->assertEquals(
+			self::EXPECTED_MIGRATION_NOTICE,
+			ob_get_clean()
+		);
+	}
+
+	/**
+	 * Test migration_notice on the Content Blocks page.
+	 *
+	 * @covers \Block_Lab\Admin\Migration::migration_notice()
+	 */
+	public function test_migration_notice_appears_on_content_blocks_page() {
+		$mock_current_screen            = new stdClass();
+		$mock_current_screen->post_type = 'block_lab';
+		$mock_current_screen->base      = 'edit';
+
+		expect( 'get_current_screen' )
+			->once()
+			->andReturn( $mock_current_screen );
+
+		ob_start();
+		$this->instance->migration_notice();
+
+		$this->assertEquals(
+			self::EXPECTED_MIGRATION_NOTICE,
+			ob_get_clean()
+		);
+	}
+
+	/**
+	 * Test migration_notice on the plugins page.
+	 *
+	 * @covers \Block_Lab\Admin\Migration::migration_notice()
+	 */
+	public function test_migration_notice_appears_on_plugins_page() {
+		$mock_current_screen       = new stdClass();
+		$mock_current_screen->base = 'plugins';
+
+		expect( 'get_current_screen' )
+			->once()
+			->andReturn( $mock_current_screen );
+
+		ob_start();
+		$this->instance->migration_notice();
+
+		$this->assertEquals(
+			self::EXPECTED_MIGRATION_NOTICE,
+			ob_get_clean()
+		);
+	}
+
+	/**
+	 * Test migration_notice on the plugins page.
+	 *
+	 * @covers \Block_Lab\Admin\Migration::migration_notice()
+	 */
+	public function test_migration_notice_appears_on_dashboard() {
+		$mock_current_screen       = new stdClass();
+		$mock_current_screen->base = 'dashboard';
+
+		expect( 'get_current_screen' )
+			->once()
+			->andReturn( $mock_current_screen );
+
+		ob_start();
+		$this->instance->migration_notice();
+
+		$this->assertEquals(
+			self::EXPECTED_MIGRATION_NOTICE,
+			ob_get_clean()
+		);
+	}
+}

--- a/tests/php/unit/admin/test-class-migration.php
+++ b/tests/php/unit/admin/test-class-migration.php
@@ -121,7 +121,7 @@ class Test_Migration extends \WP_UnitTestCase {
 		}
 
 		unset( $exception );
-		$this->assertEquals( 0, get_user_meta( get_current_user_id(), 'block_lab_show_migration_notice', true ) );
+		$this->assertEquals( 'dismissed', get_user_meta( get_current_user_id(), 'block_lab_show_migration_notice', true ) );
 	}
 
 	/**

--- a/tests/php/unit/admin/test-class-migration.php
+++ b/tests/php/unit/admin/test-class-migration.php
@@ -75,7 +75,7 @@ class Test_Migration extends \WP_UnitTestCase {
 		$this->instance->render_migration_notice();
 
 		$this->assertContains(
-			'The Block Lab team have moved. For future updates and improvements, migrate now to the new home of custom blocks: <strong>Genesis Custom Blocks.</strong>',
+			'The Block Lab team have moved. For future updates and improvements, migrate now to the new home of custom blocks: <strong>Genesis Custom Blocks</strong>.',
 			ob_get_clean()
 		);
 	}
@@ -221,7 +221,7 @@ class Test_Migration extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Give the user permissions to see the notice.
+	 * Gives the user permissions to see the notice.
 	 */
 	public function give_user_permissions() {
 		$user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );

--- a/tests/php/unit/admin/test-class-migration.php
+++ b/tests/php/unit/admin/test-class-migration.php
@@ -63,7 +63,7 @@ class Test_Migration extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Admin\Migration::render_migration_notice()
 	 */
 	public function test_render_migration_notice() {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->give_user_permissions();
 		$mock_current_screen       = new stdClass();
 		$mock_current_screen->base = 'block_lab_page_block-lab-settings';
 
@@ -86,7 +86,7 @@ class Test_Migration extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Admin\Migration::enqueue_assets()
 	 */
 	public function test_enqueue_assets() {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->give_user_permissions();
 		$mock_current_screen       = new stdClass();
 		$mock_current_screen->base = 'block_lab_page_block-lab-settings';
 
@@ -105,7 +105,7 @@ class Test_Migration extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Admin\Migration::ajax_handler_migration_notice()
 	 */
 	public function test_ajax_handler_migration_notice() {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->give_user_permissions();
 		expect( 'check_ajax_referer' )
 			->once()
 			->with(
@@ -139,7 +139,7 @@ class Test_Migration extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Admin\Migration::render_migration_notice()
 	 */
 	public function test_migration_notice_dismissed() {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->give_user_permissions();
 		$mock_current_screen       = new stdClass();
 		$mock_current_screen->base = 'block_lab_page_block-lab-settings';
 
@@ -157,7 +157,7 @@ class Test_Migration extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Admin\Migration::render_migration_notice()
 	 */
 	public function test_migration_notice_on_settings_page() {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->give_user_permissions();
 		$mock_current_screen       = new stdClass();
 		$mock_current_screen->base = 'block_lab_page_block-lab-settings';
 
@@ -174,7 +174,7 @@ class Test_Migration extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Admin\Migration::should_display_migration_notice()
 	 */
 	public function test_migration_notice_on_content_blocks_page() {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->give_user_permissions();
 		$mock_current_screen            = new stdClass();
 		$mock_current_screen->post_type = 'block_lab';
 		$mock_current_screen->base      = 'edit';
@@ -192,7 +192,7 @@ class Test_Migration extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Admin\Migration::should_display_migration_notice()
 	 */
 	public function test_migration_notice_on_plugins_page() {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->give_user_permissions();
 		$mock_current_screen       = new stdClass();
 		$mock_current_screen->base = 'plugins';
 
@@ -209,7 +209,7 @@ class Test_Migration extends \WP_UnitTestCase {
 	 * @covers \Block_Lab\Admin\Migration::should_display_migration_notice()
 	 */
 	public function test_migration_notice_on_dashboard() {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->give_user_permissions();
 		$mock_current_screen       = new stdClass();
 		$mock_current_screen->base = 'dashboard';
 
@@ -218,5 +218,17 @@ class Test_Migration extends \WP_UnitTestCase {
 			->andReturn( $mock_current_screen );
 
 		$this->assertTrue( $this->instance->should_display_migration_notice() );
+	}
+
+	/**
+	 * Give the user permissions to see the notice.
+	 */
+	public function give_user_permissions() {
+		$user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		if ( is_multisite() ) {
+			grant_super_admin( $user_id );
+		}
+
+		wp_set_current_user( $user_id );
 	}
 }

--- a/tests/php/unit/admin/test-class-migration.php
+++ b/tests/php/unit/admin/test-class-migration.php
@@ -146,7 +146,7 @@ class Test_Migration extends \WP_UnitTestCase {
 		expect( 'get_current_screen' )
 			->andReturn( $mock_current_screen );
 
-		add_user_meta( get_current_user_id(), Migration::NOTICE_USER_META_KEY, Migration::NOTICE_DISMISSED_META_VALUE );
+		update_user_meta( get_current_user_id(), Migration::NOTICE_USER_META_KEY, Migration::NOTICE_DISMISSED_META_VALUE );
 
 		$this->assertFalse( $this->instance->should_display_migration_notice() );
 	}

--- a/tests/php/unit/helpers/trait-testing-helper.php
+++ b/tests/php/unit/helpers/trait-testing-helper.php
@@ -52,25 +52,4 @@ trait Testing_Helper {
 
 		set_transient( 'block_lab_license', $transient_value );
 	}
-
-	/**
-	 * Asserts that markup is the same.
-	 *
-	 * Forked from Alain Schlesser's work:
-	 * https://github.com/ampproject/amp-wp/blob/b11c04cba3b97ebcfb40dc5833cbdb70a4cf2186/lib/optimizer/tests/src/MarkupComparison.php#L13-L30
-	 *
-	 * @param string $expected Expected markup.
-	 * @param string $actual   Actual markup.
-	 */
-	public function assert_equal_markup( $expected, $actual ) {
-		$actual   = preg_replace( '/\s+/', ' ', $actual );
-		$expected = preg_replace( '/\s+/', ' ', $expected );
-		$actual   = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $actual ) );
-		$expected = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $expected ) );
-
-		$this->assertEquals(
-			array_filter( preg_split( '#(<[^>]+>|[^<>]+)#', $expected, -1, PREG_SPLIT_DELIM_CAPTURE ) ),
-			array_filter( preg_split( '#(<[^>]+>|[^<>]+)#', $actual, -1, PREG_SPLIT_DELIM_CAPTURE ) )
-		);
-	}
 }

--- a/tests/php/unit/helpers/trait-testing-helper.php
+++ b/tests/php/unit/helpers/trait-testing-helper.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Trait with a helper method for testing controls.
+ * Trait with testing helper methods.
  *
  * @package Block_Lab
  */
 
 /**
- * Trait with a helper method.
+ * Trait with helper methods.
  */
 trait Testing_Helper {
 
@@ -51,5 +51,26 @@ trait Testing_Helper {
 		}
 
 		set_transient( 'block_lab_license', $transient_value );
+	}
+
+	/**
+	 * Asserts that markup is the same.
+	 *
+	 * Forked from Alain Schlesser's work:
+	 * https://github.com/ampproject/amp-wp/blob/b11c04cba3b97ebcfb40dc5833cbdb70a4cf2186/lib/optimizer/tests/src/MarkupComparison.php#L13-L30
+	 *
+	 * @param string $expected Expected markup.
+	 * @param string $actual   Actual markup.
+	 */
+	public function assert_equal_markup( $expected, $actual ) {
+		$actual   = preg_replace( '/\s+/', ' ', $actual );
+		$expected = preg_replace( '/\s+/', ' ', $expected );
+		$actual   = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $actual ) );
+		$expected = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $expected ) );
+
+		$this->assertEquals(
+			array_filter( preg_split( '#(<[^>]+>|[^<>]+)#', $expected, -1, PREG_SPLIT_DELIM_CAPTURE ) ),
+			array_filter( preg_split( '#(<[^>]+>|[^<>]+)#', $actual, -1, PREG_SPLIT_DELIM_CAPTURE ) )
+		);
 	}
 }


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Adds the migration and 'Not Now' notices
* On clicking 'Not Now', the migration notice never appears again for that user:
* Appears on Block Lab > Content Blocks, Block Lab > Settings, `/wp-admin/plugins.php`, and the Dashboard. 






#### Testing instructions
1. Go to Block Lab > Content Blocks, Block Lab > Settings, `/wp-admin/plugins.php`, and the Dashboard
2. Expected: the notice appears as shown above
3. Click 'Not Now'
4. Expected: the notice is hidden, and the 'Not Now' notice displays
5. Reload the page
6. Expected: The notice doesn't appear again
7. To make the notice appear again:
```sh
wp user list # Find your user ID from that
wp shell
update_user_meta( $user_id, 'block_lab_show_migration_notice', 1 ); // $user_id is the ID from the wp user list command.
```
