### PR TITLE
Update URLs in the migration

### DIFF
--- a/js/migration/components/intro.js
+++ b/js/migration/components/intro.js
@@ -16,8 +16,7 @@ import { __ } from '@wordpress/i18n';
  * @return {React.ReactElement} The introduction to the migration.
  */
 const Intro = () => {
-	// @todo: replace this.
-	const developerNoticeUrl = 'https://example.com';
+	const developerNoticeUrl = 'https://getblocklab.com/migrating-to-genesis-custom-blocks/';
 	const announcementUrl = 'https://getblocklab.com/the-block-lab-team-are-joining-wp-engine/';
 
 	return (

--- a/js/migration/components/steps/get-genesis-pro.js
+++ b/js/migration/components/steps/get-genesis-pro.js
@@ -33,8 +33,7 @@ import { ButtonNext, Step, StepContent, StepFooter, StepIcon } from '../';
  * @return {React.ReactElement} The component to get Genesis Pro.
  */
 const GetGenesisPro = ( { goToNext, isStepActive, isStepComplete, stepIndex } ) => {
-	// @todo: replace this.
-	const urlMigrateWithoutGenPro = 'https://example.com';
+	const urlMigrateWithoutGenPro = 'https://getblocklab.com/migrating-to-genesis-custom-blocks/';
 	const urlGetGenesisPro = 'https://my.wpengine.com/signup?plan=genesis-pro';
 
 	const [ isSubmittingKey, setIsSubmittingKey ] = useState( false );

--- a/js/migration/components/steps/update-hooks.js
+++ b/js/migration/components/steps/update-hooks.js
@@ -31,9 +31,8 @@ import { ButtonNext, ButtonPrevious, Step, StepContent, StepFooter, StepIcon } f
  * @return {React.ReactElement} The component to prompt to back up the site.
  */
 const UpdateHooks = ( { isStepActive, isStepComplete, stepIndex, goToNext, goToPrevious } ) => {
-	// @todo: replace this.
-	const hooksDetailsUrl = 'https://example.com/';
-	const phpApiDetailsUrl = 'https://developer.wpengine.com/genesis-custom-blocks/functions/';
+	const hooksDetailsUrl = 'https://developer.wpengine.com/genesis-custom-blocks/block-lab-hook-compatibility/';
+	const phpApiDetailsUrl = 'https://developer.wpengine.com/genesis-custom-blocks/block-lab-php-api-compatibility/';
 
 	return (
 		<Step isActive={ isStepActive } isComplete={ isStepComplete }>


### PR DESCRIPTION
#### Changes
* Updates 4 migration links, thanks to Luke for them

#### Testing instructions
1. Go to `/wp-admin` > Block Lab > Migrate
2. Verify the links are correct:
<img width="832" alt="links-here" src="https://user-images.githubusercontent.com/4063887/88433047-fbcbac00-cdc2-11ea-80e1-b0ac66a194d0.png">

<img width="912" alt="what-means" src="https://user-images.githubusercontent.com/4063887/88433328-75639a00-cdc3-11ea-89dd-5c0f52f28064.png">

<img width="595" alt="the-links" src="https://user-images.githubusercontent.com/4063887/88433388-93c99580-cdc3-11ea-8017-8dacc10998b9.png">
