### PR TITLE
Fix build of block.editor.css

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
 	...defaultConfig,
 	entry: {
 		'./js/editor.blocks': './js/blocks/index.js',
+		'./css/blocks.editor': './css/src/editor.scss',
 	},
 	output: {
 		path: path.resolve( __dirname ),


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->

#### Changes
* Before, it looks like it wasn't building `css/blocks.editor.css`. It probably still worked because the file was still in our local.
* This ensures that the file is built

#### Testing instructions
1. `cd /path/to/block-lab`
2. `rm css/blocks.editor.css && rm css/blocks.editor.asset.php` # remove the built files
3. `npm install && npm run dev`
4. Expected: the built files are present: `css/blocks.editor.css` and `css/blocks.editor.asset.php`
5. Create a block with several fields
6. Expected: the styling still looks good
