### PR TITLE
Hide the meta box arrows, as they don't work in Edit Block

### DIFF
--- a/css/admin.block-post.css
+++ b/css/admin.block-post.css
@@ -30,6 +30,10 @@
 	padding: 6px 10px;
 	margin-bottom: 6px;
 }
+.handle-order-higher,
+.handle-order-lower {
+	display: none
+}
 #block_fields a,
 #block_fields a:focus {
 	outline: none;

--- a/css/admin.block-post.css
+++ b/css/admin.block-post.css
@@ -32,7 +32,7 @@
 }
 .handle-order-higher,
 .handle-order-lower {
-	display: none
+	display: none;
 }
 #block_fields a,
 #block_fields a:focus {


### PR DESCRIPTION
<!--- Please summarize this PR in the title above -->
@RobStino, thanks for [pointing this out](https://github.com/getblocklab/block-lab/pull/673#issuecomment-673273198).

#### Changes
* It looks like WP 5.5 has arrows in meta boxes that allow moving them:

![arrows-here-](https://user-images.githubusercontent.com/4063887/90175815-9f2e3200-dd6d-11ea-81ef-62b0899f53ba.png)

* They can cause the main block config editor to be in the side, where there isn't enough room:

![clicking-twice](https://user-images.githubusercontent.com/4063887/90175670-5e361d80-dd6d-11ea-9ccb-305b8737012c.png)

* It's important to fix this now. If users change the order, they won't be able to change it back once this PR is deployed. That's because moving the meta boxes persists across page loads, and this PR hides the arrows (though they could remove the `display: none` style rule and move them back).

#### Testing instructions
1. Go to `/wp-admin` > Block Lab > All Blocks, and click a block
2. Expected: there aren't any more arrows in the meta boxes
3. Expected: the styling of the rest of the meta box still looks good
