### PR TITLE
Bump the version to 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog ##
 
+### 1.7.0 – 2021-03-31 ###
+
+Show the new Genesis Custom Blocks editor
+
+* New: A notice that mentions the new editor and a .gif of it in the migration UI
+
 ### 1.6.0 – 2020-09-02 ###
 
 Migration to Genesis Custom Blocks

--- a/block-lab.php
+++ b/block-lab.php
@@ -9,7 +9,7 @@
  * Plugin Name: Block Lab
  * Plugin URI: https://getblocklab.com
  * Description: The easy way to build custom blocks for Gutenberg.
- * Version: 1.6.0
+ * Version: 1.7.0
  * Author: Block Lab
  * Author URI: https://getblocklab.com
  * License: GPL2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "block-lab",
   "title": "Block Lab",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "WordPress plugin with a simple templating system for building custom blocks.",
   "author": "Block Lab",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION


#### Changes
* Bumps the version from `1.6.0` to `1.7.0` in the 3 places that the version is [usually bumped in](https://github.com/getblocklab/block-lab/pull/673/files).

#### Testing instructions
* `composer install && npm install && npm run build && npm run lint && npm run test:js`
(Travis stopped working, I think they now charge to do as many runs as we did)
* Just basic smoke testing that the plugin works, please